### PR TITLE
Add MATLAB parser

### DIFF
--- a/parser_matlab.py
+++ b/parser_matlab.py
@@ -1,7 +1,62 @@
 """Parser for MATLAB `.m` files used by DocGen-LM.
 
-Employs simple line-based parsing as outlined in the SRS.
-"""
+Employs simple line-based parsing as outlined in the SRS."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List
 
 
+def parse_matlab_file(path: str) -> Dict[str, Any]:
+    """Parse a MATLAB ``.m`` file and extract basic structure.
 
+    Parameters
+    ----------
+    path:
+        File to parse.
+
+    Returns
+    -------
+    dict
+        Dictionary containing the file header comments and any ``function``
+        declarations found. Each function entry provides the name of the
+        function and a list of arguments.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    # Extract leading comment lines as the file header
+    header_lines: List[str] = []
+    body_start = 0
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("%"):
+            header_lines.append(stripped.lstrip("% "))
+        elif stripped == "":
+            # allow blank lines before the header ends
+            header_lines.append("") if header_lines else None
+        else:
+            body_start = i
+            break
+    else:
+        body_start = len(lines)
+
+    header = "\n".join(header_lines).strip()
+
+    func_re = re.compile(
+        r"^\s*function\s+(?:\[[^\]]*\]|[^=]+)?=?\s*(\w+)\s*(?:\(([^)]*)\))?",
+        re.IGNORECASE,
+    )
+    functions: List[Dict[str, Any]] = []
+
+    for line in lines[body_start:]:
+        m = func_re.match(line)
+        if m:
+            name = m.group(1)
+            args = m.group(2) or ""
+            arg_list = [a.strip() for a in args.split(";") if a.strip()] if ";" in args else [a.strip() for a in args.split(",") if a.strip()]
+            functions.append({"name": name, "args": arg_list})
+
+    return {"header": header, "functions": functions}

--- a/tests/test_parser_matlab.py
+++ b/tests/test_parser_matlab.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from parser_matlab import parse_matlab_file
+
+
+def test_parse_simple_matlab(tmp_path: Path) -> None:
+    src = textwrap.dedent(
+        """
+        % Example MATLAB file
+        % Another line
+        function y = add(x, y)
+            y = x + y;
+        end
+        """
+    )
+    file = tmp_path / "sample.m"
+    file.write_text(src)
+
+    result = parse_matlab_file(str(file))
+
+    assert result["header"] == "Example MATLAB file\nAnother line"
+    assert len(result["functions"]) == 1
+    func = result["functions"][0]
+    assert func["name"] == "add"
+    assert func["args"] == ["x", "y"]
+
+
+def test_parse_multiple_functions(tmp_path: Path) -> None:
+    src = textwrap.dedent(
+        """
+        function [out1,out2] = compute(a, b)
+            out1 = a + b;
+            out2 = a - b;
+        end
+
+        function result = square(x)
+            result = x ^ 2;
+        end
+        """
+    )
+    file = tmp_path / "multi.m"
+    file.write_text(src)
+
+    result = parse_matlab_file(str(file))
+
+    assert result["header"] == ""
+    assert len(result["functions"]) == 2
+    names = [f["name"] for f in result["functions"]]
+    assert names == ["compute", "square"]
+    assert result["functions"][0]["args"] == ["a", "b"]
+    assert result["functions"][1]["args"] == ["x"]


### PR DESCRIPTION
## Summary
- implement simple MATLAB parser
- add unit tests for MATLAB parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687944ab68888322957466d00e43601e