### PR TITLE
Implement persistent caching for LLM summaries

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,7 +1,43 @@
 """Simple on-disk cache for LLM responses.
 
-Required to avoid unnecessary calls per the SRS.
-"""
+Required to avoid unnecessary calls per the SRS."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+from typing import Dict, Optional
 
 
+class ResponseCache:
+    """Persist mappings from stable keys to LLM responses."""
+
+    def __init__(self, path: str) -> None:
+        self.file = Path(path)
+        if self.file.exists():
+            try:
+                self._data: Dict[str, str] = json.loads(self.file.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                self._data = {}
+        else:
+            self._data = {}
+
+    @staticmethod
+    def make_key(file_path: str, content: str) -> str:
+        """Return a deterministic key for *file_path* and *content*."""
+        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        return f"{file_path}:{digest}"
+
+    def get(self, key: str) -> Optional[str]:
+        """Return the cached value for ``key`` if present."""
+        return self._data.get(key)
+
+    def set(self, key: str, value: str) -> None:
+        """Store ``value`` under ``key`` and persist to disk."""
+        self._data[key] = value
+        self._save()
+
+    def _save(self) -> None:
+        self.file.write_text(json.dumps(self._data, indent=2, sort_keys=True), encoding="utf-8")
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from cache import ResponseCache
+
+
+def test_cache_round_trip(tmp_path: Path) -> None:
+    cache_file = tmp_path / "cache.json"
+    cache = ResponseCache(str(cache_file))
+    key = ResponseCache.make_key("file.py", "content")
+    cache.set(key, "summary")
+
+    new_cache = ResponseCache(str(cache_file))
+    assert new_cache.get(key) == "summary"
+
+
+def test_cache_get_missing(tmp_path: Path) -> None:
+    cache = ResponseCache(str(tmp_path / "cache.json"))
+    assert cache.get("unknown") is None


### PR DESCRIPTION
## Summary
- implement `ResponseCache` for saving LLM summaries to disk
- add helper for generating stable keys using SHA256
- store cache data as JSON and persist on every update
- add unit tests verifying cache round-trip behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794ae2bbc483229ea4c9ae046a789a