### PR TITLE
Implement HTML rendering

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,22 @@
 /* Basic stylesheet for DocGen-LM output as referenced in the SRS. */
+body {
+    display: flex;
+    font-family: sans-serif;
+}
 
+.sidebar {
+    width: 200px;
+    background: #f0f0f0;
+    padding: 1rem;
+}
 
+.content {
+    flex: 1;
+    padding: 1rem;
+}
+
+pre {
+    background: #eee;
+    padding: 0.5rem;
+    overflow-x: auto;
+}

--- a/templates/template.html
+++ b/templates/template.html
@@ -1,4 +1,20 @@
-<!-- Base HTML template for DocGen-LM output.
-     Defined in the SRS as the shared Jinja2 layout. -->
-
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{title}</title>
+    <link rel="stylesheet" href="{static_path}">
+</head>
+<body>
+    <div class="sidebar">
+        <h2>Navigation</h2>
+        <ul>
+        {navigation}
+        </ul>
+    </div>
+    <div class="content">
+        <h1>{header}</h1>
+        {body}
+    </div>
+</body>
+</html>

--- a/tests/test_html_writer.py
+++ b/tests/test_html_writer.py
@@ -1,0 +1,32 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from html_writer import write_index, write_module_page
+
+
+def test_write_index(tmp_path: Path) -> None:
+    links = [("module1", "module1.html"), ("module2", "module2.html")]
+    write_index(str(tmp_path), "Project summary", links)
+    html = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert "Project summary" in html
+    assert "module1.html" in html
+    assert "<h1>Project Documentation" in html
+
+
+def test_write_module_page(tmp_path: Path) -> None:
+    links = [("index", "index.html")]
+    module_data = {
+        "name": "module1",
+        "summary": "Module summary",
+        "functions": [
+            {"name": "foo", "signature": "def foo(): pass"}
+        ],
+    }
+    write_module_page(str(tmp_path), module_data, links)
+    html = (tmp_path / "module1.html").read_text(encoding="utf-8")
+    assert "Module summary" in html
+    assert "<h2>Functions" in html
+    assert "foo" in html
+    assert "<pre" in html


### PR DESCRIPTION
## Summary
- add HTML template with sidebar and content blocks
- implement html_writer with simple templating and syntax highlighting
- style sidebar and pre blocks
- add unit tests for HTML writer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794d9eb3608322916067ac9e874a9e