### PR TITLE
Add integration tests and pytest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Required flags:
 
 The LLM must be running and reachable via `llm_client.py`.
 
+
+## Running Tests
+
+Install the test requirements (already included in requirements.txt) and run:
+
+```bash
+pytest
+```
+
 ## Documentation
 
 For the complete specification see [Docs/DocGen-LM_SRS.md](Docs/DocGen-LM_SRS.md).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -ra
+pythonpath = .
+testpaths = tests

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from docgenerator import main
+
+
+def test_docgenerator_generates_html(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    # simple python file
+    (project_dir / "hello.py").write_text('def hi():\n    """Say hi."""\n    return "hi"\n')
+    # simple matlab file
+    (project_dir / "util.m").write_text('% util function\nfunction y = util(x)\n y = x;\nend\n')
+
+    output_dir = tmp_path / "out"
+
+    with patch("docgenerator.LLMClient") as MockClient:
+        instance = MockClient.return_value
+        instance.ping.return_value = True
+        instance.summarize.return_value = "summary"
+        ret = main([str(project_dir), "--output", str(output_dir)])
+        assert ret == 0
+
+    # verify html files created
+    assert (output_dir / "index.html").exists()
+    assert (output_dir / "hello.html").exists()
+    assert (output_dir / "util.html").exists()
+
+    html = (output_dir / "hello.html").read_text(encoding="utf-8")
+    assert "summary" in html


### PR DESCRIPTION
## Summary
- add integration test that runs the CLI with mocked LLM
- add pytest configuration
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687952b6eea4832292f27a9265cc7495