### PR TITLE
Delegate stub requests to real library

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -1,12 +1,26 @@
-from .exceptions import RequestException
+import importlib
+import sys
+
+try:
+    _real_requests = importlib.import_module("requests")
+    if _real_requests is sys.modules[__name__]:
+        raise ImportError
+    from requests.exceptions import RequestException
+except Exception:  # pragma: no cover - fallback when real requests isn't available
+    _real_requests = None
+    from .exceptions import RequestException
 
 
 def get(*args, **kwargs):
-    raise NotImplementedError("requests stub: get")
+    if _real_requests is None:
+        raise NotImplementedError("requests stub: get")
+    return _real_requests.get(*args, **kwargs)
 
 
 def post(*args, **kwargs):
-    raise NotImplementedError("requests stub: post")
+    if _real_requests is None:
+        raise NotImplementedError("requests stub: post")
+    return _real_requests.post(*args, **kwargs)
 
 
 class exceptions:


### PR DESCRIPTION
## Summary
- update `requests` stub to delegate to the real library if available
- fallback to existing behaviour when the real `requests` package is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795c688d348322aeb261afc582ff58