### PR TITLE
Add options for LLM URL and model

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Required flags:
 | `--output` | Output directory for HTML files  |
 | `--ignore` | Paths to skip                    |
 
+Optional flags:
+
+| Flag          | Description                      |
+|---------------|----------------------------------|
+| `--llm-url`   | Base URL of the LLM server       |
+| `--model`     | Model name to use                |
+
 The LLM must be running and reachable via `llm_client.py`.
 
 ## Example: Running with LMStudio
@@ -39,7 +46,7 @@ The LLM must be running and reachable via `llm_client.py`.
 3. Run the documentation generator:
 
 ```bash
-python docgenerator.py ./my_project --output ./docs
+python docgenerator.py ./my_project --output ./docs --llm-url http://localhost:1234 --model local
 ```
 
 

--- a/docgenerator.py
+++ b/docgenerator.py
@@ -45,9 +45,19 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         help="Paths relative to source that should be ignored (repeatable)",
     )
+    parser.add_argument(
+        "--llm-url",
+        default="http://localhost:1234",
+        help="Base URL of the LLM API",
+    )
+    parser.add_argument(
+        "--model",
+        default="local",
+        help="Model name to use when contacting the LLM",
+    )
     args = parser.parse_args(argv)
 
-    client = LLMClient()
+    client = LLMClient(base_url=args.llm_url, model=args.model)
     try:
         client.ping()
     except ConnectionError as exc:


### PR DESCRIPTION
## Summary
- extend CLI to accept `--llm-url` and `--model`
- pass these values when creating the `LLMClient`
- document the new flags in README and update LMStudio example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687960b2ff648322b22028e94e7086a9