### PR TITLE
Remove fixed LLM timeout

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -49,7 +49,7 @@ class LLMClient:
 
         for _ in range(3):
             try:
-                response = requests.post(self.endpoint, json=payload, timeout=30)
+                response = requests.post(self.endpoint, json=payload, timeout=None)
                 response.raise_for_status()
                 data = response.json()
                 return data["choices"][0]["message"]["content"].strip()


### PR DESCRIPTION
## Summary
- wait indefinitely when contacting the LLM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879779c42f483228120d3985433bb78