### PR TITLE
Auto-skip git folders

### DIFF
--- a/Docs/DocGen-LM_SRS.md
+++ b/Docs/DocGen-LM_SRS.md
@@ -33,6 +33,7 @@ This tool produces human-readable documentation for codebases written in Python 
 - Recursively scan a specified directory
 - Identify `.py` (Python) and `.m` (MATLAB) files
 - Allow exclusion of files or folders via `--ignore`
+- Automatically skip directories named `.git`
 
 ### 2.2 Language-Specific Parsing
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Required flags:
 | `--output` | Output directory for HTML files  |
 | `--ignore` | Paths to skip                    |
 
+Directories named `.git` are ignored automatically.
+
 Optional flags:
 
 | Flag          | Description                      |

--- a/scanner.py
+++ b/scanner.py
@@ -39,8 +39,12 @@ def scan_directory(base_path: str, ignore: List[str]) -> List[str]:
 
     for root, dirs, files in os.walk(base, topdown=True):
         root_path = Path(root)
-        # prune ignored directories
-        dirs[:] = [d for d in dirs if not any(_is_subpath(root_path / d, ig) for ig in ignore_paths)]
+        # prune ignored directories and internal .git folders
+        dirs[:] = [
+            d
+            for d in dirs
+            if d != ".git" and not any(_is_subpath(root_path / d, ig) for ig in ignore_paths)
+        ]
 
         for name in files:
             if not (name.endswith(".py") or name.endswith(".m")):

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -60,3 +60,19 @@ def test_scan_directory_mixed_file_types(tmp_path: Path) -> None:
         str(tmp_path / "nested" / "six.m"),
     }
     assert set(result) == expected
+
+
+def test_scan_directory_skips_git_folder(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        [
+            "good.py",
+            os.path.join(".git", "ignored.py"),
+            os.path.join(".git", "sub", "also.py"),
+        ],
+    )
+
+    result = scan_directory(str(tmp_path), [])
+
+    assert str(tmp_path / "good.py") in result
+    assert not any(".git" in p for p in result)


### PR DESCRIPTION
## Summary
- exclude `.git` directories in `scan_directory`
- test that `.git` is ignored automatically
- note that `.git` folders are skipped in docs and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687982887e108322b819b39771cbf7c9