### PR TITLE
Add class and function summaries in documentation

### DIFF
--- a/docgenerator.py
+++ b/docgenerator.py
@@ -93,6 +93,21 @@ def main(argv: list[str] | None = None) -> int:
 
         module = {"name": Path(path).stem, "language": language, "summary": summary}
         module.update(parsed)
+
+        # generate summaries for individual classes
+        for cls in module.get("classes", []):
+            cls_text = cls.get("docstring", cls.get("name", ""))
+            cls_key = ResponseCache.make_key(f"{path}:{cls.get('name')}", cls_text)
+            cls_summary = _summarize(client, cache, cls_key, cls_text, "class-summary")
+            cls["summary"] = cls_summary
+
+        # and for standalone functions
+        for func in module.get("functions", []):
+            func_text = func.get("signature", func.get("name", ""))
+            func_key = ResponseCache.make_key(f"{path}:{func.get('name')}", func_text)
+            func_summary = _summarize(client, cache, func_key, func_text, "function-summary")
+            func["summary"] = func_summary
+
         modules.append(module)
 
     page_links = [(m["name"], f"{m['name']}.html") for m in modules]

--- a/html_writer.py
+++ b/html_writer.py
@@ -63,6 +63,8 @@ def write_module_page(output_dir: str, module_data: dict[str, Any], page_links: 
         body_parts.append("<h2>Classes</h2>")
         for cls in classes:
             body_parts.append(f'<h3 id="{cls.get("name")}">{cls.get("name")}</h3>')
+            if cls.get("summary"):
+                body_parts.append(f'<p>{cls["summary"]}</p>')
             if cls.get("docstring"):
                 body_parts.append(f'<p>{cls["docstring"]}</p>')
             for method in cls.get("methods", []):
@@ -75,6 +77,8 @@ def write_module_page(output_dir: str, module_data: dict[str, Any], page_links: 
         body_parts.append("<h2>Functions</h2>")
         for func in functions:
             body_parts.append(f'<h3 id="{func.get("name")}">{func.get("name")}</h3>')
+            if func.get("summary"):
+                body_parts.append(f'<p>{func["summary"]}</p>')
             sig = func.get("signature")
             if sig:
                 body_parts.append(_highlight(sig, language))

--- a/tests/test_docgenerator.py
+++ b/tests/test_docgenerator.py
@@ -25,3 +25,29 @@ def test_skips_invalid_python_file(tmp_path: Path) -> None:
     # only index page should be generated
     assert (output_dir / "index.html").exists()
     assert not (output_dir / "bad.html").exists()
+
+
+def test_generates_class_and_function_summaries(tmp_path: Path) -> None:
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    (project_dir / "mod.py").write_text(
+        'class Foo:\n    """Doc"""\n    pass\n\n' "def bar():\n    return 1\n"
+    )
+
+    output_dir = tmp_path / "docs"
+
+    with patch("docgenerator.LLMClient") as MockClient:
+        instance = MockClient.return_value
+        instance.ping.return_value = True
+        instance.summarize.side_effect = [
+            "module summary",
+            "class summary",
+            "function summary",
+            "project summary",
+        ]
+        ret = main([str(project_dir), "--output", str(output_dir)])
+        assert ret == 0
+
+    html = (output_dir / "mod.html").read_text(encoding="utf-8")
+    assert "class summary" in html
+    assert "function summary" in html

--- a/tests/test_html_writer.py
+++ b/tests/test_html_writer.py
@@ -20,13 +20,18 @@ def test_write_module_page(tmp_path: Path) -> None:
     module_data = {
         "name": "module1",
         "summary": "Module summary",
+        "classes": [
+            {"name": "Bar", "summary": "Class summary", "methods": []}
+        ],
         "functions": [
-            {"name": "foo", "signature": "def foo(): pass"}
+            {"name": "foo", "signature": "def foo(): pass", "summary": "Func summary"}
         ],
     }
     write_module_page(str(tmp_path), module_data, links)
     html = (tmp_path / "module1.html").read_text(encoding="utf-8")
     assert "Module summary" in html
+    assert "Class summary" in html
+    assert "Func summary" in html
     assert "<h2>Functions" in html
     assert "foo" in html
     assert "<pre" in html


### PR DESCRIPTION
## Summary
- generate summaries for each class and function when parsing modules
- display these summaries on module HTML pages
- test HTML writer with class/function summaries
- integration test ensuring summaries appear in HTML output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687992ac13108322aa5c1cbe8ebc505e