### PR TITLE
Remove jinja2 dependency

### DIFF
--- a/Docs/DocGen-LM_SRS.md
+++ b/Docs/DocGen-LM_SRS.md
@@ -94,7 +94,7 @@ Each HTML page includes:
 | `parser_matlab.py` | Parse `.m` files                       |
 | `llm_client.py`    | Interface with LMStudio                |
 | `html_writer.py`   | Render output from templates           |
-| `template.html`    | Shared Jinja2 layout                   |
+| `template.html`    | Shared HTML template                   |
 | `cache.py`         | Cache LLM responses                    |
 
 ---
@@ -105,7 +105,7 @@ Each HTML page includes:
 - Python 3.9+
 - Must use a running LMStudio or compatible local LLM API
 - Works offline except for LLM queries
-- Only basic dependencies: `requests`, `jinja2`, `pygments`
+- Only basic dependencies: `requests`, `pygments`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Clone the repository and install the required packages:
 pip install -r requirements.txt
 ```
 
-The tool depends on `requests`, `jinja2` and `pygments`.
+The tool depends on `requests` and `pygments`.
 
 ## 7. 🧪 CLI Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests
-jinja2
 pygments


### PR DESCRIPTION
## Summary
- remove jinja2 from `requirements.txt`
- document only `requests` and `pygments` in `README.md`
- update SRS to remove jinja2 as a dependency and clarify the template description

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687993eb4c9c8322af8911eb4e95057a