### PR TITLE
Improve index rendering and project summary prompt

### DIFF
--- a/docgenerator.py
+++ b/docgenerator.py
@@ -185,12 +185,13 @@ def main(argv: list[str] | None = None) -> int:
     project_outline = "\n".join(project_lines)
 
     PROJECT_PROMPT = f"""
-You are a documentation generator.
+Summarize the purpose of this codebase in 1–2 sentences.
 
-Based only on the project structure listed below, generate a short summary (1–2 sentences) of what the code implements.
-
-Do not speculate. Do not guess what the code is for. Do not refer to this summary or what is or isn’t included.
-If structure is minimal, describe it factually.
+- Base your answer only on the provided structure.
+- Do not address the reader or give usage advice.
+- Do not say "the code defines" or "this summary".
+- Prefer concise technical descriptions of what is implemented.
+- Feel free to group related functionality (e.g., grid setup, game loop).
 
 Structure:
 {project_outline}

--- a/html_writer.py
+++ b/html_writer.py
@@ -48,6 +48,16 @@ def write_index(output_dir: str, project_summary: str, page_links: Iterable[Tupl
         for text, link in page_links
     )
     body_parts = [f"<p>{html.escape(project_summary)}</p>", "<h2>Modules</h2>"]
+
+    module_items = [
+        f'<li><a href="{link}">{html.escape(text)}</a></li>'
+        for text, link in page_links
+    ]
+    if module_items:
+        body_parts.append("<ul>")
+        body_parts.extend(module_items)
+        body_parts.append("</ul>")
+
     body = "\n".join(body_parts)
     html_out = _render_html(
         "Project Documentation", "Project Documentation", body, nav_html

--- a/tests/test_html_writer.py
+++ b/tests/test_html_writer.py
@@ -11,10 +11,12 @@ def test_write_index(tmp_path: Path) -> None:
     write_index(str(tmp_path), "Project <summary> & data", links)
     html = (tmp_path / "index.html").read_text(encoding="utf-8")
     assert "Project &lt;summary&gt; &amp; data" in html
-    assert html.count("module1.html") == 1
-    assert html.count("module2.html") == 1
+    assert html.count("module1.html") == 2
+    assert html.count("module2.html") == 2
     assert "module&lt;1&gt;" in html
     assert "module&amp;2" in html
+    assert "<h2>Modules" in html
+    assert "<ul>" in html
     assert "<h1>Project Documentation" in html
 
 


### PR DESCRIPTION
## Summary
- render list of modules on the index page
- allow more expressive project summary generation
- adjust tests for new module list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6cd43dd08322b330bf22b7493748