### PR TITLE
Add module summaries to index page

### DIFF
--- a/docgenerator.py
+++ b/docgenerator.py
@@ -201,7 +201,8 @@ Structure:
     raw_summary = _summarize(client, cache, project_key, PROJECT_PROMPT, "docstring")
     project_summary = sanitize_summary(raw_summary)
 
-    write_index(str(output_dir), project_summary, page_links)
+    module_summaries = {m["name"]: m.get("summary", "") for m in modules}
+    write_index(str(output_dir), project_summary, page_links, module_summaries)
     for module in modules:
         write_module_page(str(output_dir), module, page_links)
 

--- a/html_writer.py
+++ b/html_writer.py
@@ -5,7 +5,7 @@ Renders documentation pages using simple template substitution.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Iterable, Tuple
+from typing import Any, Iterable, Tuple, Dict
 import html
 
 from pygments import highlight
@@ -39,7 +39,12 @@ def _render_html(title: str, header: str, body: str, nav_html: str) -> str:
     )
 
 
-def write_index(output_dir: str, project_summary: str, page_links: Iterable[Tuple[str, str]]) -> None:
+def write_index(
+    output_dir: str,
+    project_summary: str,
+    page_links: Iterable[Tuple[str, str]],
+    module_summaries: Dict[str, str] | None = None,
+) -> None:
     """Render ``index.html`` with *project_summary* and navigation links."""
     dest_dir = Path(output_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -47,14 +52,22 @@ def write_index(output_dir: str, project_summary: str, page_links: Iterable[Tupl
         f'<li><a href="{link}">{html.escape(text)}</a></li>'
         for text, link in page_links
     )
-    body_parts = [f"<p>{html.escape(project_summary)}</p>", "<h2>Modules</h2>"]
+    body_parts = [f"<p>{html.escape(project_summary)}</p>", "<hr/>", "<h2>Modules</h2>"]
 
-    module_items = [
-        f'<li><a href="{link}">{html.escape(text)}</a></li>'
-        for text, link in page_links
-    ]
+    module_items: list[str] = []
+    for text, link in page_links:
+        summary = (module_summaries or {}).get(text, "")
+        item = (
+            f'<li style="margin-bottom: 1em;">'
+            f'<a href="{link}">{html.escape(text)}</a>'
+        )
+        if summary:
+            item += f"<br/><small>{html.escape(summary)}</small>"
+        item += "</li>"
+        module_items.append(item)
+
     if module_items:
-        body_parts.append("<ul>")
+        body_parts.append('<ul style="list-style-type: none; padding-left: 0;">')
         body_parts.extend(module_items)
         body_parts.append("</ul>")
 

--- a/tests/test_docgenerator.py
+++ b/tests/test_docgenerator.py
@@ -53,6 +53,8 @@ def test_generates_class_and_function_summaries(tmp_path: Path) -> None:
     html = (output_dir / "mod.html").read_text(encoding="utf-8")
     assert "improved class doc" in html
     assert "function summary" in html
+    index_html = (output_dir / "index.html").read_text(encoding="utf-8")
+    assert "module summary" in index_html
 
 
 def test_skips_non_utf8_file(tmp_path: Path) -> None:

--- a/tests/test_html_writer.py
+++ b/tests/test_html_writer.py
@@ -8,7 +8,8 @@ from html_writer import write_index, write_module_page
 
 def test_write_index(tmp_path: Path) -> None:
     links = [("module<1>", "module1.html"), ("module&2", "module2.html")]
-    write_index(str(tmp_path), "Project <summary> & data", links)
+    summaries = {"module<1>": "First module.", "module&2": ""}
+    write_index(str(tmp_path), "Project <summary> & data", links, summaries)
     html = (tmp_path / "index.html").read_text(encoding="utf-8")
     assert "Project &lt;summary&gt; &amp; data" in html
     assert html.count("module1.html") == 2
@@ -16,7 +17,10 @@ def test_write_index(tmp_path: Path) -> None:
     assert "module&lt;1&gt;" in html
     assert "module&amp;2" in html
     assert "<h2>Modules" in html
-    assert "<ul>" in html
+    assert "<ul" in html
+    assert "<small>First module." in html
+    # only one summary should be rendered
+    assert html.count("<small>") == 1
     assert "<h1>Project Documentation" in html
 
 


### PR DESCRIPTION
## Summary
- enhance `write_index` in `html_writer.py` to display module summaries and improved layout
- pass module summaries from `docgenerator.py`
- adjust tests for new index format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a72ecc3e4832295e11f69a4e6e870