### PR TITLE
Add README summarization template

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -29,6 +29,17 @@ _COMMON_RULES = (
     "- Just describe what is implemented.\n\n"
 )
 
+README_PROMPT = (
+    "You are a documentation engine.\n\n"
+    "Below is Markdown content from a README or documentation file. "
+    "Use this to enrich the overall project summary. Focus on describing the code’s purpose, features, and architecture.\n\n"
+    "- Do not include setup or installation steps\n"
+    "- Do not refer to the Markdown file itself\n"
+    "- Avoid list formatting or markdown\n"
+    "- Output 2–3 sentences suitable for use in technical documentation\n"
+    "- Do not speculate. Use only the provided content."
+)
+
 PROMPT_TEMPLATES: Dict[str, str] = {
     "module": (
         "Summarize the module below.\n\n" + _COMMON_RULES + "Code:\n```python\n{text}\n```"
@@ -39,9 +50,7 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     "function": (
         "Summarize the function below.\n\n" + _COMMON_RULES + "Code:\n```python\n{text}\n```"
     ),
-    "readme": (
-        "Summarize the documentation below.\n\n" + _COMMON_RULES + "{text}"
-    ),
+    "readme": README_PROMPT + "\n{text}",
     "project": (
         "You are a documentation generator.\n\n"
         "Write a short project summary using only the information provided below.\n"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -85,3 +85,16 @@ def test_prompt_varies_by_type() -> None:
     assert func_prompt == PROMPT_TEMPLATES["function"].format(text="foo")
     assert class_prompt != func_prompt
 
+
+def test_readme_prompt_template_used() -> None:
+    client = LLMClient("http://fake")
+    mock_response = Mock()
+    mock_response.raise_for_status = Mock()
+    mock_response.json.return_value = {"choices": [{"message": {"content": "x"}}]}
+
+    with patch("llm_client.requests.post", return_value=mock_response) as post:
+        client.summarize("foo", "readme")
+        readme_prompt = post.call_args[1]["json"]["messages"][1]["content"]
+
+    assert readme_prompt == PROMPT_TEMPLATES["readme"].format(text="foo")
+


### PR DESCRIPTION
## Summary
- add README_PROMPT constant for README summarization
- update PROMPT_TEMPLATES to use the new template for readmes
- add unit test verifying README template usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a75c556ec8322b664a2914507f93d