### PR TITLE
Add HTML reviewer tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 pygments
+beautifulsoup4

--- a/reviewer.py
+++ b/reviewer.py
@@ -1,0 +1,150 @@
+"""Post-generation documentation reviewer for DocGen-LM HTML output."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Iterable, List
+
+from bs4 import BeautifulSoup
+
+from llm_client import sanitize_summary
+
+
+ASSISTANT_PHRASES = [
+    "you can",
+    "note that",
+    "this summary",
+    "here's how",
+    "to run",
+    "we can",
+    "let's",
+    "should you",
+    "if you want",
+]
+
+HALLUCINATION_TERMS = [
+    "tic-tac-toe",
+    "checkers",
+    "pizza",
+    "weather",
+    "recipe",
+]
+
+
+def _is_generated_html(text: str) -> bool:
+    """Return True if *text* looks like DocGen-LM output."""
+    if "<h1>Project Documentation</h1>" in text:
+        return True
+    if re.search(r"<h2[^>]*>Class:", text):
+        return True
+    if re.search(r"<h3[^>]*>Method:", text):
+        return True
+    return False
+
+
+def _find_line_number(html: str, phrase: str) -> int:
+    for i, line in enumerate(html.splitlines(), 1):
+        if phrase.lower() in line.lower():
+            return i
+    return -1
+
+
+def check_assistant_phrasing(soup: BeautifulSoup, html: str) -> List[str]:
+    """Return list of assistant-like phrases found."""
+    findings: List[str] = []
+    for p in soup.find_all("p"):
+        text = p.get_text(strip=True)
+        lower = text.lower()
+        for phrase in ASSISTANT_PHRASES:
+            if phrase in lower:
+                line_no = _find_line_number(html, text)
+                findings.append(f'"{text}" (line {line_no})')
+                break
+    return findings
+
+
+def check_contradictions(soup: BeautifulSoup) -> List[str]:
+    """Return list of contradiction descriptions."""
+    findings: List[str] = []
+    summary_text = " ".join(p.get_text(" ", strip=True).lower() for p in soup.find_all("p")[:2])
+    methods = soup.find_all(
+        "h3", string=lambda s: isinstance(s, str) and s.strip().startswith("Method:")
+    )
+    functions = [
+        h
+        for h in soup.find_all("h3")
+        if not (isinstance(h.string, str) and h.string.strip().startswith("Method:"))
+    ]
+    classes = soup.find_all(
+        "h2", string=lambda s: isinstance(s, str) and s.strip().startswith("Class:")
+    )
+    if "no methods" in summary_text and methods:
+        findings.append(f"'no methods' stated but found {len(methods)} method headers")
+    if "no functions" in summary_text and functions:
+        findings.append(f"'no functions' stated but found {len(functions)} function headers")
+    if "no classes" in summary_text and classes:
+        findings.append(f"'no classes' stated but found {len(classes)} class headers")
+    return findings
+
+
+def check_hallucinations(soup: BeautifulSoup) -> List[str]:
+    """Return list of hallucination phrases detected."""
+    findings: List[str] = []
+    for p in soup.find_all("p"):
+        text = p.get_text(" ", strip=True).lower()
+        for term in HALLUCINATION_TERMS:
+            if term in text:
+                findings.append(term)
+    return findings
+
+
+def _sanitize_paragraphs(soup: BeautifulSoup) -> None:
+    for p in soup.find_all("p"):
+        cleaned = sanitize_summary(p.get_text())
+        p.string = cleaned
+
+
+def _review_file(path: Path, autofix: bool = False) -> List[str]:
+    html = path.read_text(encoding="utf-8")
+    if not _is_generated_html(html):
+        return []
+    soup = BeautifulSoup(html, "html.parser")
+    results: List[str] = []
+    for snippet in check_assistant_phrasing(soup, html):
+        results.append(f"[ASSISTANT] {path.name}: {snippet}")
+    for desc in check_contradictions(soup):
+        results.append(f"[CONTRADICTION] {path.name}: {desc}")
+    for term in check_hallucinations(soup):
+        results.append(f"[HALLUCINATION] {path.name}: '{term}' mentioned")
+    if autofix and results:
+        _sanitize_paragraphs(soup)
+        path.write_text(str(soup), encoding="utf-8")
+    return results
+
+
+def review_directory(directory: Path, autofix: bool = False) -> None:
+    for file in directory.rglob("*.html"):
+        try:
+            results = _review_file(file, autofix=autofix)
+        except Exception as exc:  # pragma: no cover - unexpected parse failure
+            print(f"Error reading {file}: {exc}")
+            continue
+        for line in results:
+            print(line)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Review generated HTML documentation")
+    parser.add_argument("directory", help="Path to the HTML output directory")
+    parser.add_argument("--autofix", action="store_true", help="Rewrite files to fix issues")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    review_directory(Path(args.directory), autofix=args.autofix)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    raise SystemExit(main())
+

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from reviewer import main
+from html_writer import write_module_page, write_index
+
+
+def _make_module(tmp_path: Path, summary: str, methods=None) -> Path:
+    data = {
+        "name": "mod",
+        "summary": summary,
+        "classes": [],
+        "functions": [],
+    }
+    if methods is not None:
+        data["classes"] = [
+            {"name": "Foo", "docstring": "", "summary": "", "methods": methods}
+        ]
+    write_module_page(str(tmp_path), data, [("index", "index.html")])
+    return tmp_path / "mod.html"
+
+
+def test_assistant_phrasing_detected(tmp_path: Path, capsys) -> None:
+    _make_module(tmp_path, "You can use this class.")
+    main([str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "[ASSISTANT]" in out
+    assert "mod.html" in out
+
+
+def test_contradiction_detected(tmp_path: Path, capsys) -> None:
+    methods = [{"name": "bar", "signature": "def bar()", "docstring": "", "source": ""}]
+    _make_module(tmp_path, "No methods defined", methods)
+    main([str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "[CONTRADICTION]" in out
+
+
+def test_hallucination_detected(tmp_path: Path, capsys) -> None:
+    _make_module(tmp_path, "Implements tic-tac-toe features")
+    main([str(tmp_path)])
+    out = capsys.readouterr().out
+    assert "[HALLUCINATION]" in out
+
+
+def test_autofix_removes_phrasing(tmp_path: Path) -> None:
+    html_path = _make_module(tmp_path, "You can call this.")
+    main([str(tmp_path), "--autofix"])
+    html = html_path.read_text(encoding="utf-8")
+    assert "You can" not in html


### PR DESCRIPTION
## Summary
- add reviewer.py to inspect generated HTML docs
- implement checks for assistant phrasing, contradictions, and hallucinations
- support optional autofix
- update requirements for beautifulsoup4
- add unit tests for reviewer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_687a78bdc5048322b031624525dddc8e