### PR TITLE
Add index link in module HTML navigation

### DIFF
--- a/html_writer.py
+++ b/html_writer.py
@@ -84,10 +84,14 @@ def write_module_page(output_dir: str, module_data: dict[str, Any], page_links: 
     dest_dir.mkdir(parents=True, exist_ok=True)
     module_name = module_data.get("name", "module")
     language = module_data.get("language", "python")
-    nav_html = "\n".join(
+    nav_items = [
+        '<li><a href="index.html"><strong>🏠 Project Overview</strong></a></li>'
+    ]
+    nav_items.extend(
         f'<li><a href="{link}">{html.escape(text)}</a></li>'
         for text, link in page_links
     )
+    nav_html = "\n".join(nav_items)
 
     body_parts = [f"<p>{html.escape(module_data.get('summary', ''))}</p>"]
 

--- a/tests/test_html_writer.py
+++ b/tests/test_html_writer.py
@@ -25,7 +25,7 @@ def test_write_index(tmp_path: Path) -> None:
 
 
 def test_write_module_page(tmp_path: Path) -> None:
-    links = [("index", "index.html")]
+    links = [("OtherModule", "other.html")]
     module_data = {
         "name": "module1",
         "summary": "Module <summary>",
@@ -56,6 +56,8 @@ def test_write_module_page(tmp_path: Path) -> None:
     }
     write_module_page(str(tmp_path), module_data, links)
     html = (tmp_path / "module1.html").read_text(encoding="utf-8")
+    assert '<a href="index.html"><strong>🏠 Project Overview</strong></a>' in html
+    assert html.count('other.html') == 1
     assert "Module &lt;summary&gt;" in html
     assert "<h2 id=\"Bar\">Class: Bar</h2>" in html
     assert "Bar docs &amp; stuff" in html


### PR DESCRIPTION
## Summary
- add a link to the homepage in module navigation
- update tests for new navigation behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_687a83dc4c888322acc0651aba548362