### PR TITLE
Remove redundant requests shim

### DIFF
--- a/requests.py
+++ b/requests.py
@@ -1,4 +1,0 @@
-import sys
-from pip._vendor import requests as _requests
-
-sys.modules[__name__] = _requests


### PR DESCRIPTION
## Summary
- delete `requests.py` shim
- rely on the real `requests` library

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687a8ac9754c8322ac1517c95dacc1e2