### PR TITLE
Add tiktoken support and warn when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Clone the repository and install the required packages:
 pip install -r requirements.txt
 ```
 
-The tool depends on `requests` and `pygments`.
+The tool depends on `requests`, `pygments`, and `beautifulsoup4`. Install
+`tiktoken` for accurate token counting as listed in `requirements.txt`.
 
 ## 7. 🧪 CLI Usage
 

--- a/docgenerator.py
+++ b/docgenerator.py
@@ -62,6 +62,11 @@ def _get_tokenizer():
         except Exception:  # pragma: no cover - fallback if model unknown
             return tiktoken.encoding_for_model("gpt-3.5-turbo")
 
+    print(
+        "[WARNING] tiktoken is not installed; token counts will be approximate.",
+        file=sys.stderr,
+    )
+
     class _Simple:
         def encode(self, text: str):
             return text.split()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 pygments
 beautifulsoup4
+tiktoken

--- a/tests/test_docgenerator.py
+++ b/tests/test_docgenerator.py
@@ -166,3 +166,25 @@ def test_clean_output_dir(tmp_path: Path) -> None:
     assert not generated.exists()
     assert custom.exists()
     assert asset.exists()
+
+
+def test_summarize_chunked_splits_long_text(tmp_path: Path) -> None:
+    from cache import ResponseCache
+    from docgenerator import _get_tokenizer, _summarize_chunked
+
+    tokenizer = _get_tokenizer()
+    text = "word " * 50
+    cache = ResponseCache(str(tmp_path / "cache.json"))
+
+    with patch("docgenerator._summarize", return_value="summary") as mock_sum:
+        _summarize_chunked(
+            client=object(),
+            cache=cache,
+            key_prefix="k",
+            text=text,
+            prompt_type="module",
+            tokenizer=tokenizer,
+            max_context_tokens=10,
+            chunk_token_budget=5,
+        )
+        assert mock_sum.call_count > 1


### PR DESCRIPTION
## Summary
- include `tiktoken` in the requirements
- document `tiktoken` installation for accurate token counting
- warn if `tiktoken` isn't installed when retrieving a tokenizer
- test that `_summarize_chunked` splits long input

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687b1b56663c8322b56e1b34794ee3bd