### PR TITLE
Use chunked summarization for README

### DIFF
--- a/docgenerator.py
+++ b/docgenerator.py
@@ -370,7 +370,16 @@ def main(argv: list[str] | None = None) -> int:
     readme_summary = ""
     if md_context:
         readme_key = ResponseCache.make_key("README", md_context)
-        readme_summary = _summarize(client, cache, readme_key, md_context, "readme")
+        readme_summary = _summarize_chunked(
+            client,
+            cache,
+            readme_key,
+            md_context,
+            "readme",
+            tokenizer,
+            max_context_tokens,
+            chunk_token_budget,
+        )
         readme_summary = sanitize_summary(readme_summary)
 
     PROJECT_PROMPT = f"""

--- a/tests/test_docgenerator.py
+++ b/tests/test_docgenerator.py
@@ -132,21 +132,13 @@ def test_readme_summary_used(tmp_path: Path) -> None:
     with patch("docgenerator.LLMClient") as MockClient:
         instance = MockClient.return_value
         instance.ping.return_value = True
-        instance.summarize.side_effect = [
-            "module summary",
-            "readme summary",
-            "project summary",
-            "function summary",
-            "improved function doc",
-        ]
+        instance.summarize.side_effect = lambda text, pt: f"{pt} summary"
         ret = main([str(project_dir), "--output", str(output_dir)])
         assert ret == 0
 
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     assert "readme summary" in html
-    assert any(
-        args[1] == "readme" for args, _ in instance.summarize.call_args_list
-    )
+    assert any(call.args[1] == "readme" for call in instance.summarize.call_args_list)
 
 
 def test_clean_output_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- chunk README docs when summarizing to avoid context overflow
- sanitize README summary
- relax test checking README summarization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687b20e6c11c83228d33c992b689557a