### PR TITLE
Use chunked project summary

### DIFF
--- a/docgenerator.py
+++ b/docgenerator.py
@@ -382,21 +382,17 @@ def main(argv: list[str] | None = None) -> int:
         )
         readme_summary = sanitize_summary(readme_summary)
 
-    PROJECT_PROMPT = f"""
-Summarize the purpose of this codebase in 1–2 sentences.
-
-- Base your answer only on the provided structure.
-- Do not address the reader or give usage advice.
-- Do not say "the code defines" or "this summary".
-- Prefer concise technical descriptions of what is implemented.
-- Feel free to group related functionality (e.g., grid setup, game loop).
-
-Structure:
-{project_outline}
-"""
-
     project_key = ResponseCache.make_key("PROJECT", project_outline)
-    raw_summary = _summarize(client, cache, project_key, PROJECT_PROMPT, "docstring")
+    raw_summary = _summarize_chunked(
+        client,
+        cache,
+        project_key,
+        project_outline,
+        "project",
+        tokenizer,
+        max_context_tokens,
+        chunk_token_budget,
+    )
     project_summary = sanitize_summary(raw_summary)
     if readme_summary:
         project_summary = f"{readme_summary}\n{project_summary}".strip()

--- a/tests/test_docgenerator.py
+++ b/tests/test_docgenerator.py
@@ -119,6 +119,7 @@ def test_project_summary_is_sanitized(tmp_path: Path) -> None:
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     assert "You can run this" not in html
     assert "It prints." in html
+    assert any(call.args[1] == "project" for call in instance.summarize.call_args_list)
 
 
 def test_readme_summary_used(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- remove obsolete PROJECT_PROMPT constant
- summarize project outline via `_summarize_chunked`
- verify project prompt type is used in project summary test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687b21c9c81c8322a725f3096b58de40