### PR TITLE
Update README and remove SRS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DocGen-LM
 
-DocGen-LM generates static HTML documentation for Python and MATLAB projects by analyzing source files and summarizing them with a local LLM.
+DocGen-LM generates static HTML documentation for Python and MATLAB projects by analyzing source files and summarizing them with a local LLM. It now captures and renders **nested functions** and **subclasses**, so complex structures appear in the output as expandable sections.
 
 ## Prerequisites
 
@@ -65,4 +65,4 @@ pytest
 
 ## Documentation
 
-For the complete specification see [Docs/DocGen-LM_SRS.md](Docs/DocGen-LM_SRS.md).
+Generated HTML documentation can be found in the **Docs/** directory.


### PR DESCRIPTION
## Summary
- document that nested functions and subclasses are now rendered
- remove dead SRS link from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687b3b47a1e08322837a06e3a43cc7d2