### PR TITLE
Add progress bars with optional tqdm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 pygments
 beautifulsoup4
 tiktoken
+tqdm


### PR DESCRIPTION
## Summary
- add optional tqdm import for progress bars
- show progress for modules, classes, and methods/functions
- include tqdm in requirements

## Testing
- `pytest -q` *(fails: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443): Max retries exceeded with url: /encodings/cl100k_base.tiktoken (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_6892d48f32388322a272626845b2db33