### PR TITLE
Add explaincode summary utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ pip install -r requirements.txt
 The tool depends on `requests`, `pygments`, and `beautifulsoup4`. It uses the
 real `requests` library to communicate with LMStudio. Install
 `tiktoken` for accurate token counting as listed in `requirements.txt`.
+For the `explaincode` summary utility, additional packages
+`markdown`, `python-docx`, and `reportlab` are required.
 
 ## 7. 🧪 CLI Usage
 
@@ -62,6 +64,16 @@ Install the test requirements (already included in requirements.txt) and run:
 ```bash
 pytest
 ```
+
+## Project Summary Utility
+
+Generate a lightweight overview of an existing project and its documentation:
+
+```bash
+python explaincode.py --path ./my_project
+```
+
+Use `--output-format pdf` to produce a PDF report (requires `reportlab`).
 
 ## Documentation
 

--- a/explaincode.py
+++ b/explaincode.py
@@ -1,0 +1,156 @@
+"""Generate a project summary from existing documentation and sample files."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Iterable
+
+from bs4 import BeautifulSoup
+
+try:  # optional dependency
+    import markdown  # type: ignore
+except Exception:  # pragma: no cover - optional import
+    markdown = None
+
+try:  # optional dependency
+    from docx import Document  # type: ignore
+except Exception:  # pragma: no cover - optional import
+    Document = None
+
+try:  # optional dependency
+    from reportlab.lib.pagesizes import letter
+    from reportlab.pdfgen import canvas
+except Exception:  # pragma: no cover - optional import
+    canvas = None
+    letter = None
+
+
+def collect_files(base: Path) -> Iterable[Path]:
+    """Return files from *base* relevant for summarisation."""
+    files = []
+    docs_dir = base / "Docs"
+    if docs_dir.is_dir():
+        files.extend(docs_dir.glob("*.html"))
+
+    root_patterns = ["README.md", "*.md", "*.txt", "*.docx", "*.html"]
+    for pattern in root_patterns:
+        files.extend(base.glob(pattern))
+
+    sample_patterns = ["*.json", "*.csv", "*.txt"]
+    for pattern in sample_patterns:
+        files.extend(base.glob(pattern))
+
+    seen = set()
+    unique = []
+    for f in files:
+        if f.is_file() and f not in seen:
+            unique.append(f)
+            seen.add(f)
+    return unique
+
+
+def extract_text(path: Path) -> str:
+    """Extract plain text from ``path`` based on its file type."""
+    suffix = path.suffix.lower()
+    try:
+        if suffix == ".html":
+            content = path.read_text(encoding="utf-8")
+            soup = BeautifulSoup(content, "html.parser")
+            return soup.get_text("\n")
+        if suffix in {".md"}:
+            content = path.read_text(encoding="utf-8")
+            if markdown is not None:
+                html = markdown.markdown(content)
+                soup = BeautifulSoup(html, "html.parser")
+                return soup.get_text("\n")
+            return content
+        if suffix == ".docx" and Document is not None:
+            doc = Document(str(path))
+            return "\n".join(p.text for p in doc.paragraphs)
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        return ""
+
+
+def infer_sections(text: str) -> Dict[str, str]:
+    """Naively infer documentation sections from ``text``."""
+    sections = {
+        "Overview": "",
+        "How to Use It": "",
+        "Inputs and Outputs": "",
+        "System Requirements": "",
+    }
+    for line in text.splitlines():
+        lower = line.lower()
+        if not sections["Overview"] and any(k in lower for k in ["overview", "purpose", "project"]):
+            sections["Overview"] = line.strip()
+        if not sections["How to Use It"] and any(k in lower for k in ["use", "usage", "run", "execute"]):
+            sections["How to Use It"] = line.strip()
+        if not sections["Inputs and Outputs"] and any(k in lower for k in ["input", "output"]):
+            sections["Inputs and Outputs"] = line.strip()
+        if not sections["System Requirements"] and any(k in lower for k in ["requirement", "dependency", "requires"]):
+            sections["System Requirements"] = line.strip()
+
+    for key, value in sections.items():
+        if not value:
+            sections[key] = "No information available."
+    return sections
+
+
+def render_html(sections: Dict[str, str]) -> str:
+    """Return HTML for ``sections``."""
+    parts = [
+        "<html><head><meta charset='utf-8'>",
+        "<style>body{font-family:Arial,sans-serif;margin:20px;}h2{color:#2c3e50;}</style>",
+        "</head><body>",
+    ]
+    for title, content in sections.items():
+        parts.append(f"<h2>{title}</h2><p>{content}</p>")
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
+def write_pdf(html: str, path: Path) -> bool:
+    """Write ``html`` to ``path`` as a PDF. Returns ``True`` on success."""
+    if canvas is None:  # pragma: no cover - optional branch
+        return False
+    text = BeautifulSoup(html, "html.parser").get_text().splitlines()
+    c = canvas.Canvas(str(path), pagesize=letter)
+    textobject = c.beginText(40, 750)
+    for line in text:
+        textobject.textLine(line)
+    c.drawText(textobject)
+    c.save()
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Summarise project documentation")
+    parser.add_argument("--path", default=".", help="target project directory")
+    parser.add_argument(
+        "--output-format", choices=["html", "pdf"], default="html",
+        help="output format for the summary",
+    )
+    args = parser.parse_args(argv)
+
+    target = Path(args.path)
+    files = collect_files(target)
+    texts = [extract_text(f) for f in files]
+    combined = "\n".join(t for t in texts if t)
+
+    sections = infer_sections(combined)
+    html = render_html(sections)
+
+    if args.output_format == "html":
+        (target / "summary.html").write_text(html, encoding="utf-8")
+    else:
+        success = write_pdf(html, target / "summary.pdf")
+        if not success:
+            print("PDF generation requires the reportlab package.")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ pygments
 beautifulsoup4
 tiktoken
 tqdm
+markdown
+python-docx
+reportlab

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[metadata]
+name = docgen-lm
+version = 0.1.0
+
+author = ""
+
+[options]
+py_modules = explaincode
+
+[options.entry_points]
+console_scripts =
+    explaincode = explaincode:main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()

--- a/tests/test_explaincode.py
+++ b/tests/test_explaincode.py
@@ -1,0 +1,44 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+from explaincode import main
+
+
+def _create_fixture(tmp_path: Path) -> None:
+    docs = tmp_path / "Docs"
+    docs.mkdir()
+    (docs / "page.html").write_text("<html><body><h1>Overview</h1></body></html>", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# Demo\n\nUsage: run it", encoding="utf-8")
+    (tmp_path / "sample.json").write_text("{\"input\": \"data\"}", encoding="utf-8")
+
+
+def test_html_summary_creation(tmp_path: Path) -> None:
+    _create_fixture(tmp_path)
+    main(["--path", str(tmp_path)])
+    assert (tmp_path / "summary.html").exists()
+
+
+def test_pdf_summary_creation(tmp_path: Path) -> None:
+    if importlib.util.find_spec("reportlab") is None:
+        pytest.skip("reportlab not installed")
+    _create_fixture(tmp_path)
+    main(["--path", str(tmp_path), "--output-format", "pdf"])
+    assert (tmp_path / "summary.pdf").exists()
+
+
+def test_graceful_missing_docx(monkeypatch, tmp_path: Path) -> None:
+    _create_fixture(tmp_path)
+    try:
+        from docx import Document
+    except Exception:  # pragma: no cover - dependency missing
+        Document = None  # type: ignore
+    if Document:
+        doc = Document()
+        doc.add_paragraph("hi")
+        doc.save(tmp_path / "guide.docx")
+    import explaincode
+    monkeypatch.setattr(explaincode, "Document", None)
+    main(["--path", str(tmp_path)])
+    assert (tmp_path / "summary.html").exists()


### PR DESCRIPTION
## Summary
- add `explaincode` script to summarise existing project documentation and optionally output PDF
- document and require supporting libraries
- test HTML/PDF generation and fallback behaviour for missing formats

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement markdown)*
- `pytest` *(fails: requests.exceptions.ProxyError: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443))*


------
https://chatgpt.com/codex/tasks/task_e_6894a257bd688322a60493a3dd958d29