### PR TITLE
docs: simplify CLI Usage heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ real `requests` library to communicate with LMStudio. Install
 For the `explaincode` summary utility, additional packages
 `markdown`, `python-docx`, and `reportlab` are required.
 
-## 7. 🧪 CLI Usage
+## CLI Usage
 
 ```bash
 python docgenerator.py ./my_project --output ./docs


### PR DESCRIPTION
## Summary
- remove outdated numbering and emoji from CLI usage section

## Testing
- `pytest` *(fails: ProxyError - HTTPSConnectionPool; 14 failed, 31 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6894a644ef548322beca85608abd5c36