### PR TITLE
Allow custom system prompts

### DIFF
--- a/explaincode.py
+++ b/explaincode.py
@@ -195,7 +195,7 @@ def _summarize_manual(client: LLMClient, text: str) -> str:
     if not text:
         return ""
     if _count_tokens(text) <= 2000 and len(text) <= 6000:
-        return client.summarize(text, "user_manual")
+        return client.summarize(text, "user_manual", system_prompt=MERGE_SYSTEM_PROMPT)
 
     parts = _split_text(text)
     partials = [

--- a/llm_client.py
+++ b/llm_client.py
@@ -142,7 +142,7 @@ class LLMClient:
             raise ConnectionError(f"Unable to reach LMStudio at {self.base_url}") from exc
 
     def summarize(
-        self, text: str, prompt_type: str, system_prompt: str | None = None
+        self, text: str, prompt_type: str, system_prompt: str = SYSTEM_PROMPT
     ) -> str:
         """Return a summary for ``text`` using ``prompt_type`` template."""
 
@@ -153,7 +153,7 @@ class LLMClient:
             "model": self.model,
             "temperature": 0.3,
             "messages": [
-                {"role": "system", "content": system_prompt or SYSTEM_PROMPT},
+                {"role": "system", "content": system_prompt},
                 {"role": "user", "content": prompt},
             ],
         }

--- a/tests/test_explaincode.py
+++ b/tests/test_explaincode.py
@@ -20,7 +20,7 @@ def _create_fixture(tmp_path: Path) -> None:
 
 def _mock_llm_client() -> object:
     class Dummy:
-        def summarize(self, text: str, prompt_type: str, system_prompt: str | None = None) -> str:  # pragma: no cover - simple stub
+        def summarize(self, text: str, prompt_type: str, system_prompt: str = "") -> str:  # pragma: no cover - simple stub
             return textwrap.dedent(
                 """
                 Overview: Demo project


### PR DESCRIPTION
## Summary
- support custom system prompts in `LLMClient.summarize`
- use manual-specific prompts during manual documentation generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894e346179483229c2aca4ab215a55a