### PR TITLE
Refactor manual summarization utilities

### DIFF
--- a/explaincode.py
+++ b/explaincode.py
@@ -9,10 +9,9 @@ import re
 import subprocess
 import tempfile
 import shutil
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Iterable
+from typing import Dict, Iterable
 import sys
 import time
 import ast
@@ -20,8 +19,13 @@ import ast
 from bs4 import BeautifulSoup
 
 from llm_client import LLMClient
-from chunk_utils import get_tokenizer, chunk_text
 from cache import ResponseCache
+from manual_utils import (
+    CHUNK_SYSTEM_PROMPT,
+    MERGE_SYSTEM_PROMPT,
+    _summarize_manual,
+    find_placeholders,
+)
 
 try:  # optional dependency
     import markdown  # type: ignore
@@ -230,12 +234,8 @@ def extract_text(path: Path) -> str:
 
 def detect_placeholders(text: str) -> list[str]:
     """Return section names still marked by placeholder tokens."""
-
-    missing: list[str] = []
-    for name, token in SECTION_PLACEHOLDERS.items():
-        if token in text:
-            missing.append(name)
-    return missing
+    tokens = find_placeholders(text)
+    return [name for name, token in SECTION_PLACEHOLDERS.items() if token in tokens]
 
 
 def rank_code_files(root: Path, patterns: list[str]) -> list[Path]:
@@ -410,20 +410,6 @@ def llm_generate_manual(
 generate_manual_from_docs = llm_generate_manual
 
 
-TOKENIZER = get_tokenizer()
-CHUNK_SYSTEM_PROMPT = (
-    "You are generating part of a user manual. Based on the context provided, "
-    "write a section of the guide covering purpose, usage, inputs, outputs, and behavior. "
-    "Do not describe individual functions or implementation details. Focus on user-level instructions."
-)
-MERGE_SYSTEM_PROMPT = (
-    "You are compiling a user manual. Combine the provided sections into a cohesive guide. "
-    "Ensure the manual includes sections for Overview, Purpose & Problem Solving, How to Run, "
-    "Inputs, Outputs, System Requirements, and Examples. If information for any section is "
-    "missing, insert the corresponding placeholder token such as [[NEEDS_RUN_INSTRUCTIONS]]. "
-    "Do not describe individual functions or implementation details; concentrate on user-level instructions."
-)
-
 FILL_SYSTEM_PROMPT = (
     "You are enhancing a user manual. Use the provided code snippets to replace placeholder tokens "
     "with the missing information. Do not describe individual functions or implementation details; "
@@ -455,57 +441,6 @@ def llm_fill_placeholders(
     return result
 
 
-def _count_tokens(text: str) -> int:
-    """Return the approximate token count for ``text``."""
-
-    return len(TOKENIZER.encode(text))
-
-
-def _split_text(text: str, max_tokens: int = 2000, max_chars: int = 6000) -> list[str]:
-    """Split ``text`` into chunks respecting ``max_tokens`` and ``max_chars``.
-
-    Splitting occurs on paragraph boundaries (double newlines). If a single
-    paragraph exceeds the limits, it is further split using ``chunk_text``.
-    """
-
-    paragraphs = re.split(r"\n{2,}", text.strip())
-    chunks: list[str] = []
-    current: list[str] = []
-    token_count = 0
-    char_count = 0
-    for para in paragraphs:
-        para = para.strip()
-        if not para:
-            continue
-        ptokens = _count_tokens(para)
-        pchars = len(para)
-        if ptokens > max_tokens or pchars > max_chars:
-            if current:
-                chunks.append("\n\n".join(current).strip())
-                current = []
-                token_count = 0
-                char_count = 0
-            for piece in chunk_text(para, TOKENIZER, max_tokens):
-                chunks.append(piece.strip())
-            continue
-        if (
-            token_count + ptokens > max_tokens
-            or char_count + pchars > max_chars
-        ):
-            if current:
-                chunks.append("\n\n".join(current).strip())
-            current = [para]
-            token_count = ptokens
-            char_count = pchars
-        else:
-            current.append(para)
-            token_count += ptokens
-            char_count += pchars
-    if current:
-        chunks.append("\n\n".join(current).strip())
-    return chunks
-
-
 def _edit_chunks_in_editor(chunks: list[str]) -> list[str]:
     """Open ``chunks`` in user's editor for optional modification.
 
@@ -525,176 +460,6 @@ def _edit_chunks_in_editor(chunks: list[str]) -> list[str]:
     Path(tmp.name).unlink(missing_ok=True)
     parts = re.split(r"\n\s*---\s*\n", data)
     return [p.strip() for p in parts if p.strip()]
-
-
-def _summarize_manual(
-    client: LLMClient,
-    cache: ResponseCache,
-    text: str,
-    chunking: str = "auto",
-    source: str = "combined",
-    post_chunk_hook: Callable[[list[str]], list[str]] | None = None,
-) -> str:
-    """Return a manual summary for ``text`` using ``chunking`` strategy."""
-
-    if not text:
-        return ""
-    within_limits = _count_tokens(text) <= 2000 and len(text) <= 6000
-
-    if chunking == "manual" or (chunking == "auto" and not within_limits):
-        try:
-            parts = _split_text(text)
-        except Exception as exc:  # pragma: no cover - defensive
-            print(f"[WARN] Chunking failed: {exc}", file=sys.stderr)
-            sections = infer_sections(text)
-            return "\n".join(f"{k}: {v}" for k, v in sections.items())
-
-        total = len(parts)
-        partials: dict[int, str] = {}
-        work: list[tuple[int, str, str]] = []
-        for idx, part in enumerate(parts, 1):
-            logging.debug(
-                "Chunk %s/%s from %s: %s tokens, %s characters",
-                idx,
-                total,
-                source,
-                _count_tokens(part),
-                len(part),
-            )
-            key = ResponseCache.make_key(f"{source}:chunk{idx}", part)
-            cached = cache.get(key)
-            if cached is not None:
-                partials[idx] = cached
-                logging.debug(
-                    "LLM response %s/%s length: %s characters",
-                    idx,
-                    total,
-                    len(cached),
-                )
-            else:
-                work.append((idx, part, key))
-
-        if work:
-            with ThreadPoolExecutor() as executor:
-                future_map = {
-                    executor.submit(
-                        client.summarize,
-                        part,
-                        "docstring",
-                        system_prompt=CHUNK_SYSTEM_PROMPT,
-                    ): (idx, key)
-                    for idx, part, key in work
-                }
-                for future in as_completed(future_map):
-                    idx, key = future_map[future]
-                    try:
-                        resp = future.result()
-                    except Exception as exc:  # pragma: no cover - network failure
-                        print(
-                            f"[WARN] Summarization failed for chunk {idx}/{total}: {exc}",
-                            file=sys.stderr,
-                        )
-                        continue
-                    cache.set(key, resp)
-                    logging.debug(
-                        "LLM response %s/%s length: %s characters",
-                        idx,
-                        total,
-                        len(resp),
-                    )
-                    partials[idx] = resp
-
-        if not partials:
-            sections = infer_sections(text)
-            return "\n".join(f"{k}: {v}" for k, v in sections.items())
-
-        if post_chunk_hook:
-            try:
-                ordered = [partials[i] for i in sorted(partials)]
-                ordered = post_chunk_hook(ordered)
-                partials = {i + 1: v for i, v in enumerate(ordered)}
-            except Exception as exc:  # pragma: no cover - defensive
-                logging.debug("Chunk post-processing failed: %s", exc)
-
-        merge_input = "\n\n".join(partials[i] for i in sorted(partials))
-        tokens = _count_tokens(merge_input)
-        chars = len(merge_input)
-        iteration = 0
-        while tokens > 2000 or chars > 6000:
-            iteration += 1
-            logging.info(
-                "Hierarchical merge pass %s: %s tokens, %s characters",
-                iteration,
-                tokens,
-                chars,
-            )
-            try:
-                sub_parts = _split_text(merge_input)
-            except Exception as exc:  # pragma: no cover - defensive
-                print(f"[WARN] Hierarchical split failed: {exc}", file=sys.stderr)
-                break
-            new_partials: list[str] = []
-            total = len(sub_parts)
-            for idx, piece in enumerate(sub_parts, 1):
-                logging.debug(
-                    "Merge chunk %s/%s: %s tokens, %s characters",
-                    idx,
-                    total,
-                    _count_tokens(piece),
-                    len(piece),
-                )
-                key = ResponseCache.make_key(
-                    f"{source}:merge{iteration}:chunk{idx}", piece
-                )
-                cached = cache.get(key)
-                if cached is not None:
-                    resp = cached
-                else:
-                    try:
-                        resp = client.summarize(
-                            piece, "docstring", system_prompt=MERGE_SYSTEM_PROMPT
-                        )
-                    except Exception as exc:  # pragma: no cover - network failure
-                        print(
-                            f"[WARN] Hierarchical summarization failed for chunk {idx}/{total}: {exc}",
-                            file=sys.stderr,
-                        )
-                        continue
-                    cache.set(key, resp)
-                new_partials.append(resp)
-            if not new_partials:
-                break
-            merge_input = "\n\n".join(new_partials)
-            tokens = _count_tokens(merge_input)
-            chars = len(merge_input)
-        key = ResponseCache.make_key(f"{source}:final", merge_input)
-        cached = cache.get(key)
-        if cached is not None:
-            final_resp = cached
-        else:
-            try:
-                final_resp = client.summarize(
-                    merge_input, "docstring", system_prompt=MERGE_SYSTEM_PROMPT
-                )
-                cache.set(key, final_resp)
-            except Exception as exc:  # pragma: no cover - network failure
-                print(f"[WARN] Merge failed: {exc}", file=sys.stderr)
-                return merge_input
-        logging.debug("Merged LLM response length: %s characters", len(final_resp))
-        return final_resp
-
-    if chunking == "none" and not within_limits:
-        print(
-            "[WARN] Content exceeds token or character limits; chunking disabled.",
-            file=sys.stderr,
-        )
-    key = ResponseCache.make_key(f"{source}:full", text)
-    cached = cache.get(key)
-    if cached is not None:
-        return cached
-    resp = client.summarize(text, "user_manual", system_prompt=MERGE_SYSTEM_PROMPT)
-    cache.set(key, resp)
-    return resp
 
 
 

--- a/manual_utils.py
+++ b/manual_utils.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable, Set
+
+from cache import ResponseCache
+from chunk_utils import chunk_text, get_tokenizer
+from llm_client import LLMClient
+
+
+TOKENIZER = get_tokenizer()
+
+CHUNK_SYSTEM_PROMPT = (
+    "You are generating part of a user manual. Based on the context provided, "
+    "write a section of the guide covering purpose, usage, inputs, outputs, and behavior. "
+    "Do not describe individual functions or implementation details. Focus on user-level instructions."
+)
+
+MERGE_SYSTEM_PROMPT = (
+    "You are compiling a user manual. Combine the provided sections into a cohesive guide. "
+    "Ensure the manual includes sections for Overview, Purpose & Problem Solving, How to Run, "
+    "Inputs, Outputs, System Requirements, and Examples. If information for any section is "
+    "missing, insert the corresponding placeholder token such as [[NEEDS_RUN_INSTRUCTIONS]]. "
+    "Do not describe individual functions or implementation details; concentrate on user-level instructions."
+)
+
+
+def _count_tokens(text: str) -> int:
+    """Return the approximate token count for ``text``."""
+    return len(TOKENIZER.encode(text))
+
+
+def _split_text(text: str, max_tokens: int = 2000, max_chars: int = 6000) -> list[str]:
+    """Split ``text`` into chunks respecting ``max_tokens`` and ``max_chars``."""
+    paragraphs = re.split(r"\n{2,}", text.strip())
+    chunks: list[str] = []
+    current: list[str] = []
+    token_count = 0
+    char_count = 0
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+        ptokens = _count_tokens(para)
+        pchars = len(para)
+        if ptokens > max_tokens or pchars > max_chars:
+            if current:
+                chunks.append("\n\n".join(current).strip())
+                current = []
+                token_count = 0
+                char_count = 0
+            for piece in chunk_text(para, TOKENIZER, max_tokens):
+                chunks.append(piece.strip())
+            continue
+        if token_count + ptokens > max_tokens or char_count + pchars > max_chars:
+            if current:
+                chunks.append("\n\n".join(current).strip())
+            current = [para]
+            token_count = ptokens
+            char_count = pchars
+        else:
+            current.append(para)
+            token_count += ptokens
+            char_count += pchars
+    if current:
+        chunks.append("\n\n".join(current).strip())
+    return chunks
+
+
+def chunk_docs(docs: list[str], token_limit: int = 2000) -> list[str]:
+    """Split ``docs`` into roughly ``token_limit`` sized chunks."""
+    text = "\n\n".join(d.strip() for d in docs if d and d.strip())
+    if not text:
+        return []
+    return _split_text(text, max_tokens=token_limit, max_chars=token_limit * 3)
+
+
+PLACEHOLDER_RE = re.compile(r"\[\[[^\[\]]+\]\]")
+
+
+def find_placeholders(text: str) -> Set[str]:
+    """Return placeholder tokens of the form ``[[TOKEN]]`` found in ``text``."""
+    return set(PLACEHOLDER_RE.findall(text))
+
+
+def _summarize_manual(
+    client: LLMClient,
+    cache: ResponseCache,
+    text: str,
+    chunking: str = "auto",
+    source: str = "combined",
+    post_chunk_hook: Callable[[list[str]], list[str]] | None = None,
+) -> str:
+    """Return a manual summary for ``text`` using ``chunking`` strategy."""
+    if not text:
+        return ""
+
+    from explaincode import infer_sections  # imported lazily to avoid circular dependency
+
+    within_limits = _count_tokens(text) <= 2000 and len(text) <= 6000
+
+    if chunking == "manual" or (chunking == "auto" and not within_limits):
+        try:
+            parts = _split_text(text)
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"[WARN] Chunking failed: {exc}", file=sys.stderr)
+            sections = infer_sections(text)
+            return "\n".join(f"{k}: {v}" for k, v in sections.items())
+
+        total = len(parts)
+        partials: dict[int, str] = {}
+        work: list[tuple[int, str, str]] = []
+        for idx, part in enumerate(parts, 1):
+            logging.debug(
+                "Chunk %s/%s from %s: %s tokens, %s characters",
+                idx,
+                total,
+                source,
+                _count_tokens(part),
+                len(part),
+            )
+            key = ResponseCache.make_key(f"{source}:chunk{idx}", part)
+            cached = cache.get(key)
+            if cached is not None:
+                partials[idx] = cached
+                logging.debug(
+                    "LLM response %s/%s length: %s characters",
+                    idx,
+                    total,
+                    len(cached),
+                )
+            else:
+                work.append((idx, part, key))
+
+        if work:
+            with ThreadPoolExecutor() as executor:
+                future_map = {
+                    executor.submit(
+                        client.summarize,
+                        part,
+                        "docstring",
+                        system_prompt=CHUNK_SYSTEM_PROMPT,
+                    ): (idx, key)
+                    for idx, part, key in work
+                }
+                for future in as_completed(future_map):
+                    idx, key = future_map[future]
+                    try:
+                        resp = future.result()
+                    except Exception as exc:  # pragma: no cover - network failure
+                        print(
+                            f"[WARN] Summarization failed for chunk {idx}/{total}: {exc}",
+                            file=sys.stderr,
+                        )
+                        continue
+                    cache.set(key, resp)
+                    logging.debug(
+                        "LLM response %s/%s length: %s characters",
+                        idx,
+                        total,
+                        len(resp),
+                    )
+                    partials[idx] = resp
+
+        if not partials:
+            sections = infer_sections(text)
+            return "\n".join(f"{k}: {v}" for k, v in sections.items())
+
+        if post_chunk_hook:
+            try:
+                ordered = [partials[i] for i in sorted(partials)]
+                ordered = post_chunk_hook(ordered)
+                partials = {i + 1: v for i, v in enumerate(ordered)}
+            except Exception as exc:  # pragma: no cover - defensive
+                logging.debug("Chunk post-processing failed: %s", exc)
+
+        merge_input = "\n\n".join(partials[i] for i in sorted(partials))
+        tokens = _count_tokens(merge_input)
+        chars = len(merge_input)
+        iteration = 0
+        while tokens > 2000 or chars > 6000:
+            iteration += 1
+            logging.info(
+                "Hierarchical merge pass %s: %s tokens, %s characters",
+                iteration,
+                tokens,
+                chars,
+            )
+            try:
+                sub_parts = _split_text(merge_input)
+            except Exception as exc:  # pragma: no cover - defensive
+                print(f"[WARN] Hierarchical split failed: {exc}", file=sys.stderr)
+                break
+            new_partials: list[str] = []
+            total = len(sub_parts)
+            for idx, piece in enumerate(sub_parts, 1):
+                logging.debug(
+                    "Merge chunk %s/%s: %s tokens, %s characters",
+                    idx,
+                    total,
+                    _count_tokens(piece),
+                    len(piece),
+                )
+                key = ResponseCache.make_key(
+                    f"{source}:merge{iteration}:chunk{idx}", piece
+                )
+                cached = cache.get(key)
+                if cached is not None:
+                    resp = cached
+                else:
+                    try:
+                        resp = client.summarize(
+                            piece, "docstring", system_prompt=MERGE_SYSTEM_PROMPT
+                        )
+                    except Exception as exc:  # pragma: no cover - network failure
+                        print(
+                            f"[WARN] Hierarchical summarization failed for chunk {idx}/{total}: {exc}",
+                            file=sys.stderr,
+                        )
+                        continue
+                    cache.set(key, resp)
+                new_partials.append(resp)
+            if not new_partials:
+                break
+            merge_input = "\n\n".join(new_partials)
+            tokens = _count_tokens(merge_input)
+            chars = len(merge_input)
+        key = ResponseCache.make_key(f"{source}:final", merge_input)
+        cached = cache.get(key)
+        if cached is not None:
+            final_resp = cached
+        else:
+            try:
+                final_resp = client.summarize(
+                    merge_input, "docstring", system_prompt=MERGE_SYSTEM_PROMPT
+                )
+                cache.set(key, final_resp)
+            except Exception as exc:  # pragma: no cover - network failure
+                print(f"[WARN] Merge failed: {exc}", file=sys.stderr)
+                return merge_input
+        logging.debug("Merged LLM response length: %s characters", len(final_resp))
+        return final_resp
+
+    if chunking == "none" and not within_limits:
+        print(
+            "[WARN] Content exceeds token or character limits; chunking disabled.",
+            file=sys.stderr,
+        )
+    key = ResponseCache.make_key(f"{source}:full", text)
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+    resp = client.summarize(text, "user_manual", system_prompt=MERGE_SYSTEM_PROMPT)
+    cache.set(key, resp)
+    return resp

--- a/tests/test_explaincode.py
+++ b/tests/test_explaincode.py
@@ -11,6 +11,7 @@ from bs4 import BeautifulSoup
 
 import explaincode
 from explaincode import main
+import manual_utils
 from cache import ResponseCache
 
 
@@ -328,7 +329,7 @@ def test_chunking_triggers_multiple_calls_and_logs(
     client = Dummy()
     cache = ResponseCache(str(tmp_path / "cache.json"))
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, force=True)
-    result = explaincode._summarize_manual(
+    result = manual_utils._summarize_manual(
         client, cache, text, chunking="auto", source="src"
     )
 
@@ -367,7 +368,7 @@ def test_chunk_edit_hook_applied(tmp_path: Path) -> None:
 
     client = Dummy()
     cache = ResponseCache(str(tmp_path / "cache.json"))
-    result = explaincode._summarize_manual(
+    result = manual_utils._summarize_manual(
         client, cache, text, chunking="auto", source="src", post_chunk_hook=hook
     )
 
@@ -389,7 +390,7 @@ def test_parallel_chunk_summarization(tmp_path: Path) -> None:
     client = SlowClient()
     cache = ResponseCache(str(tmp_path / "cache.json"))
     start = time.perf_counter()
-    explaincode._summarize_manual(client, cache, text, chunking="auto", source="src")
+    manual_utils._summarize_manual(client, cache, text, chunking="auto", source="src")
     duration = time.perf_counter() - start
     assert duration < delay * 1.5
 
@@ -415,7 +416,7 @@ def test_hierarchical_merge_logged(
     client = Dummy()
     cache = ResponseCache(str(tmp_path / "cache.json"))
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, force=True)
-    result = explaincode._summarize_manual(
+    result = manual_utils._summarize_manual(
         client, cache, text, chunking="auto", source="src"
     )
 
@@ -442,7 +443,7 @@ def test_cached_chunks_reused(tmp_path: Path) -> None:
     cache_file = tmp_path / "cache.json"
     cache = ResponseCache(str(cache_file))
     client1 = Dummy()
-    result1 = explaincode._summarize_manual(
+    result1 = manual_utils._summarize_manual(
         client1, cache, text, chunking="auto", source="src"
     )
     assert result1 == "resp3"
@@ -450,7 +451,7 @@ def test_cached_chunks_reused(tmp_path: Path) -> None:
 
     client2 = Dummy()
     cache2 = ResponseCache(str(cache_file))
-    result2 = explaincode._summarize_manual(
+    result2 = manual_utils._summarize_manual(
         client2, cache2, text, chunking="auto", source="src"
     )
     assert result2 == "resp3"

--- a/tests/test_manual_utils.py
+++ b/tests/test_manual_utils.py
@@ -1,0 +1,18 @@
+import manual_utils
+
+
+def _count(text: str) -> int:
+    return len(manual_utils.TOKENIZER.encode(text))
+
+
+def test_chunk_docs_respects_token_limit() -> None:
+    docs = ["a " * 1000, "b " * 1000, "c " * 1000]
+    chunks = manual_utils.chunk_docs(docs, token_limit=2000)
+    assert len(chunks) == 2
+    assert all(_count(c) <= 2000 for c in chunks)
+
+
+def test_find_placeholders() -> None:
+    text = "Intro [[NEEDS_OVERVIEW]] middle [[FOO]] end"
+    tokens = manual_utils.find_placeholders(text)
+    assert tokens == {"[[NEEDS_OVERVIEW]]", "[[FOO]]"}


### PR DESCRIPTION
## Summary
- extract `_split_text` and `_summarize_manual` into new `manual_utils` module
- add `chunk_docs` helper and `find_placeholders` token search
- update `detect_placeholders` and tests for new utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896031da33c83228161aa5b71755f11