### PR TITLE
Handle oversized files in extract_snippets

### DIFF
--- a/explaincode.py
+++ b/explaincode.py
@@ -301,7 +301,11 @@ def extract_snippets(
             continue
         if size > max_bytes:
             logging.info(
-                "Skipping %s: exceeds max bytes (elapsed %.2fs)", path, elapsed
+                "Skipping %s: file size %d exceeds limit %d bytes (elapsed %.2fs)",
+                path,
+                size,
+                max_bytes,
+                elapsed,
             )
             continue
         try:

--- a/tests/test_explaincode.py
+++ b/tests/test_explaincode.py
@@ -100,6 +100,20 @@ def test_detect_placeholders() -> None:
     assert set(missing) == {"Overview", "Outputs"}
 
 
+def test_extract_snippets_skips_large_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    big_file = tmp_path / "big.py"
+    big_file.write_bytes(b"a" * 210_000)
+    caplog.set_level(logging.INFO)
+    snippets = explaincode.extract_snippets(
+        [big_file], max_files=1, time_budget=5, max_bytes=200_000
+    )
+    assert big_file not in snippets
+    log = caplog.text
+    assert "file size" in log and "exceeds limit" in log
+
+
 
 
 def test_full_docs_no_code_scan(


### PR DESCRIPTION
## Summary
- Skip code files whose size exceeds the max bytes per file limit before reading
- Log skipped files with their actual size and configured limit
- Test that oversized files are ignored during snippet extraction

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689606c090c4832293959e10d18a1024