### PR TITLE
Ensure explaincode progress bar enabled by default

### DIFF
--- a/explaincode.py
+++ b/explaincode.py
@@ -18,8 +18,18 @@ import ast
 
 try:
     from tqdm import tqdm
-except ImportError:  # pragma: no cover - optional import
-    tqdm = lambda x, **kwargs: x
+except Exception:  # pragma: no cover - optional import
+    def tqdm(iterable, **kwargs):
+        """Fallback progress iterator when tqdm is unavailable."""
+        total = len(iterable) if hasattr(iterable, "__len__") else None
+        desc = kwargs.get("desc", "")
+        for i, item in enumerate(iterable, 1):
+            if total:
+                print(f"\r{desc} {i}/{total}", end="", file=sys.stderr)
+            else:
+                print(f"\r{desc} {i}", end="", file=sys.stderr)
+            yield item
+        print(file=sys.stderr)
 
 from bs4 import BeautifulSoup
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ author = ""
 
 [options]
 py_modules = explaincode
+install_requires =
+    tqdm
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
## Summary
- add a simple progress iterator fallback when `tqdm` is unavailable
- declare `tqdm` as a required dependency so progress bars show by default

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests', 'bs4')*


------
https://chatgpt.com/codex/tasks/task_e_68961355e1d48322b7d1b772296d8df0