### PR TITLE
Recursively chunk long partial summaries to honor token budget

### DIFF
--- a/docgenerator.py
+++ b/docgenerator.py
@@ -167,7 +167,16 @@ def _summarize_chunked(
         if len(items) == 1:
             single = items[0]
             key = ResponseCache.make_key(f"{key_prefix}:merge{depth}:solo", single)
-            return _summarize(client, cache, key, single, "docstring")
+            return _summarize_chunked(
+                client,
+                cache,
+                key,
+                single,
+                "docstring",
+                tokenizer,
+                max_context_tokens,
+                chunk_token_budget,
+            )
         groups: list[list[str]] = []
         current: list[str] = []
         current_tokens = 0
@@ -259,7 +268,16 @@ def _summarize_module_chunked(
         if len(items) == 1:
             single = items[0]
             key = ResponseCache.make_key(f"{key_prefix}:merge{depth}:solo", single)
-            return _summarize(client, cache, key, single, "docstring")
+            return _summarize_chunked(
+                client,
+                cache,
+                key,
+                single,
+                "docstring",
+                tokenizer,
+                max_context_tokens,
+                chunk_token_budget,
+            )
         groups: list[list[str]] = []
         current: list[str] = []
         current_tokens = 0

--- a/tests/test_docgenerator.py
+++ b/tests/test_docgenerator.py
@@ -252,6 +252,45 @@ def test_merge_recurses_when_prompt_too_long(tmp_path: Path) -> None:
         assert len(merge_calls) > 1
 
 
+def test_single_long_partial_is_recursively_chunked(tmp_path: Path) -> None:
+    from cache import ResponseCache
+    from chunk_utils import get_tokenizer
+    from docgenerator import _summarize_chunked
+    from llm_client import SYSTEM_PROMPT, PROMPT_TEMPLATES
+
+    tokenizer = get_tokenizer()
+    text = "word " * 200
+    cache = ResponseCache(str(tmp_path / "cache.json"))
+    template = PROMPT_TEMPLATES["module"]
+    overhead = len(tokenizer.encode(SYSTEM_PROMPT)) + len(tokenizer.encode(template.format(text="")))
+    max_context_tokens = overhead + 50
+
+    def fake_sum(client, cache_obj, key, text_arg, prompt_type):
+        template = PROMPT_TEMPLATES.get(prompt_type, PROMPT_TEMPLATES["module"])
+        overhead_local = len(tokenizer.encode(SYSTEM_PROMPT)) + len(
+            tokenizer.encode(template.format(text=""))
+        )
+        available = max_context_tokens - overhead_local
+        assert len(tokenizer.encode(text_arg)) <= available
+        if prompt_type == "module":
+            return "long " * 200
+        return "short"
+
+    with patch("docgenerator._summarize", side_effect=fake_sum) as mock_sum:
+        _summarize_chunked(
+            client=object(),
+            cache=cache,
+            key_prefix="k",
+            text=text,
+            prompt_type="module",
+            tokenizer=tokenizer,
+            max_context_tokens=max_context_tokens,
+            chunk_token_budget=10,
+        )
+        doc_calls = [c for c in mock_sum.call_args_list if c.args[4] == "docstring"]
+        assert len(doc_calls) > 1
+
+
 def test_structured_chunker_keeps_functions_atomic(tmp_path: Path) -> None:
     from cache import ResponseCache
     from parser_python import parse_python_file


### PR DESCRIPTION
## Summary
- Recursively chunk long merged summaries in `_summarize_chunked` and `_summarize_module_chunked` so single items exceeding the context limit are re-chunked before calling the LLM.
- Add tests ensuring a long partial summary triggers recursive chunking and all `_summarize` inputs remain within the allowed token budget.

## Testing
- `pytest tests/test_docgenerator.py::test_single_long_partial_is_recursively_chunked -q`
- `pytest tests/test_docgenerator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689630bf2df083228e9a7f8ae2ed3b2f