### PR TITLE
Add responsive sidebar toggle

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -25,3 +25,29 @@ pre {
     padding: 0.5rem;
     overflow-x: auto;
 }
+
+/* Toggle button hidden by default */
+#sidebar-toggle {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    #sidebar-toggle {
+        display: block;
+        margin: 0.5rem;
+    }
+    .sidebar.hidden {
+        display: none;
+    }
+}
+
+@media (max-width: 768px) {
+    body { display: block; }
+    .sidebar {
+        position: relative;
+        width: 100%;
+        height: auto;
+        overflow: visible;
+    }
+    .content { margin-left: 0; }
+}

--- a/static/toggle.js
+++ b/static/toggle.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var toggleButton = document.getElementById('sidebar-toggle');
+    var sidebar = document.querySelector('.sidebar');
+    if (toggleButton && sidebar) {
+        toggleButton.addEventListener('click', function () {
+            sidebar.classList.toggle('hidden');
+        });
+    }
+});

--- a/templates/template.html
+++ b/templates/template.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="{static_path}">
 </head>
 <body>
+    <button id="sidebar-toggle">Menu</button>
     <div class="sidebar">
         <h2>Navigation</h2>
         <ul>
@@ -16,5 +17,6 @@
         <h1>{header}</h1>
         {body}
     </div>
+    <script src="static/toggle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add responsive media query for narrow screens and optional sidebar toggle styles
- include toggle button and script to hide/show sidebar on mobile

## Testing
- `pytest` *(fails: KeyboardInterrupt after 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689def82da748322b09ead71f8fd5094