### PR TITLE
Document manual title option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Specify a custom destination for the summary with `--output`:
 python explaincode.py --path ./my_project --output ./summaries
 ```
 
+Set the manual title with `--title`:
+
+```bash
+python explaincode.py --path ./my_project --title "My Project Manual"
+```
+
 Use `--output-format pdf` to produce a PDF report (requires `reportlab`).
 
 Control how text is split with `--chunking`:


### PR DESCRIPTION
## Summary
- Clarify that the `--title` flag sets the manual title in the Project Summary Utility.
- Provide example usage showing how to specify a custom manual title.

## Testing
- ⚠️ `pytest` (interrupted after 13 tests; suite did not complete)
- ✅ `pytest tests/test_cache.py tests/test_chunk_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_689e29583fbc8322a84986fb656c653e