### PR TITLE
Expand scanner to support C++, header, and Java files

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -20,7 +20,7 @@ def _is_subpath(path: Path, parent: Path) -> bool:
 
 
 def scan_directory(base_path: str, ignore: List[str]) -> List[str]:
-    """Recursively discover ``.py`` and ``.m`` files under *base_path*.
+    """Recursively discover ``.py``, ``.m``, ``.cpp``, ``.h``, and ``.java`` files under *base_path*.
 
     Parameters
     ----------
@@ -47,7 +47,7 @@ def scan_directory(base_path: str, ignore: List[str]) -> List[str]:
         ]
 
         for name in files:
-            if not (name.endswith(".py") or name.endswith(".m")):
+            if not name.endswith((".py", ".m", ".cpp", ".h", ".java")):
                 continue
             file_path = root_path / name
             if any(_is_subpath(file_path, ig) for ig in ignore_paths):

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -76,3 +76,30 @@ def test_scan_directory_skips_git_folder(tmp_path: Path) -> None:
 
     assert str(tmp_path / "good.py") in result
     assert not any(".git" in p for p in result)
+
+
+def test_scan_directory_supports_cpp_h_java(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        [
+            "main.cpp",
+            "header.h",
+            "Program.java",
+            os.path.join("nested", "util.cpp"),
+            os.path.join("nested", "helper.h"),
+            os.path.join("nested", "Example.java"),
+            "skip.txt",
+        ],
+    )
+
+    result = scan_directory(str(tmp_path), [])
+
+    expected = {
+        str(tmp_path / "main.cpp"),
+        str(tmp_path / "header.h"),
+        str(tmp_path / "Program.java"),
+        str(tmp_path / "nested" / "util.cpp"),
+        str(tmp_path / "nested" / "helper.h"),
+        str(tmp_path / "nested" / "Example.java"),
+    }
+    assert set(result) == expected


### PR DESCRIPTION
## Summary
- support `.cpp`, `.h`, and `.java` source file discovery in scanner
- document new extensions
- add unit test covering discovery of the new extensions

## Testing
- `pytest tests/test_scanner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad200752388322900aba9048207e2b