### PR TITLE
Add basic C++ and Java parsers with tests

### DIFF
--- a/parser_cpp.py
+++ b/parser_cpp.py
@@ -1,0 +1,146 @@
+"""Simple parser for C++ files used by DocGen-LM.
+
+This module employs straightforward line-based parsing to extract
+namespaces, classes, functions and public variables. It returns a
+structure compatible with :func:`parse_python_file` containing
+``module_docstring``, ``classes`` and ``functions``. Each item also
+stores its ``source`` snippet and any leading documentation comments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+def _get_preceding_comment(lines: List[str], idx: int) -> str:
+    """Collect contiguous comment lines appearing before ``idx``."""
+
+    comments: List[str] = []
+    j = idx - 1
+    while j >= 0:
+        line = lines[j].strip()
+        if line.startswith("//"):
+            comments.insert(0, line.lstrip("/ "))
+            j -= 1
+            continue
+        if line.endswith("*/"):
+            block: List[str] = []
+            block.insert(0, line)
+            j -= 1
+            while j >= 0 and "/*" not in lines[j]:
+                block.insert(0, lines[j])
+                j -= 1
+            if j >= 0:
+                block.insert(0, lines[j])
+            cleaned = [b.strip().lstrip("/* ").rstrip("*/ ") for b in block]
+            comments = cleaned + comments
+            break
+        if line == "":
+            if comments:
+                break
+            j -= 1
+            continue
+        break
+    return "\n".join(c for c in comments if c).strip()
+
+
+def _extract_block(lines: List[str], start: int) -> Tuple[str, int]:
+    """Return text and ending index for block starting at ``start``."""
+
+    text_lines = [lines[start]]
+    brace = lines[start].count("{") - lines[start].count("}")
+    i = start + 1
+    while i < len(lines) and brace > 0:
+        line = lines[i]
+        text_lines.append(line)
+        brace += line.count("{") - line.count("}")
+        i += 1
+    return "\n".join(text_lines), i - 1
+
+
+def _parse_class_body(lines: List[str], start: int, end: int) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Parse class body and return lists of public methods and variables."""
+
+    methods: List[Dict[str, Any]] = []
+    variables: List[Dict[str, Any]] = []
+    access = "private"
+    i = start
+    while i <= end:
+        line = lines[i].strip()
+        if line in {"public:", "protected:", "private:"}:
+            access = line.rstrip(":")
+            i += 1
+            continue
+        if access == "public":
+            if "(" in line and line.rstrip().endswith("{"):
+                sig = line.rstrip("{").strip()
+                name = sig.split("(")[0].split()[-1]
+                doc = _get_preceding_comment(lines, i)
+                block, end_idx = _extract_block(lines, i)
+                methods.append({"name": name, "signature": sig, "docstring": doc, "source": block})
+                i = end_idx + 1
+                continue
+            if line.endswith(";") and "(" not in line:
+                parts = line.rstrip(";").split()
+                if parts:
+                    name = parts[-1]
+                    vartype = " ".join(parts[:-1])
+                    doc = _get_preceding_comment(lines, i)
+                    variables.append({"name": name, "type": vartype, "docstring": doc, "source": lines[i]})
+        i += 1
+    return methods, variables
+
+
+def parse_cpp_file(path: str) -> Dict[str, Any]:
+    """Parse a C++ source file and return structured information."""
+
+    text = Path(path).read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    # Module-level comment
+    first_code = 0
+    while first_code < len(lines):
+        stripped = lines[first_code].strip()
+        if stripped == "" or stripped.startswith("//") or stripped.startswith("/*"):
+            first_code += 1
+            continue
+        break
+    module_docstring = _get_preceding_comment(lines, first_code)
+
+    namespace = None
+    classes: List[Dict[str, Any]] = []
+    functions: List[Dict[str, Any]] = []
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if namespace is None and stripped.startswith("namespace "):
+            namespace = stripped.split()[1]
+            if namespace.endswith("{"):
+                namespace = namespace[:-1]
+        if stripped.startswith("class ") or stripped.startswith("struct "):
+            name = stripped.split()[1]
+            if name.endswith("{"):
+                name = name[:-1]
+            doc = _get_preceding_comment(lines, i)
+            block, end_idx = _extract_block(lines, i)
+            methods, variables = _parse_class_body(lines, i + 1, end_idx - 1)
+            classes.append({"name": name, "docstring": doc, "methods": methods, "variables": variables, "source": block})
+            i = end_idx + 1
+            continue
+        if "(" in stripped and stripped.endswith("{") and not stripped.startswith(("if", "for", "while", "switch")) and "class " not in stripped and "struct " not in stripped:
+            sig = stripped.rstrip("{").strip()
+            name = sig.split("(")[0].split()[-1]
+            doc = _get_preceding_comment(lines, i)
+            block, end_idx = _extract_block(lines, i)
+            functions.append({"name": name, "signature": sig, "docstring": doc, "source": block})
+            i = end_idx + 1
+            continue
+        i += 1
+
+    result: Dict[str, Any] = {"module_docstring": module_docstring, "classes": classes, "functions": functions}
+    if namespace:
+        result["namespace"] = namespace
+    return result

--- a/parser_java.py
+++ b/parser_java.py
@@ -1,0 +1,123 @@
+"""Simple parser for Java files used by DocGen-LM.
+
+Extracts package, classes, public methods and variables using naive
+line-based parsing. The output mirrors ``parse_python_file`` with keys
+``module_docstring``, ``classes`` and ``functions`` (typically empty for
+Java). Each entry includes its source code and leading documentation
+comments (Javadoc or ``//``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+def _get_preceding_comment(lines: List[str], idx: int) -> str:
+    comments: List[str] = []
+    j = idx - 1
+    while j >= 0:
+        line = lines[j].strip()
+        if line.startswith("//"):
+            comments.insert(0, line.lstrip("/ "))
+            j -= 1
+            continue
+        if line.endswith("*/"):
+            block: List[str] = []
+            block.insert(0, line)
+            j -= 1
+            while j >= 0 and "/*" not in lines[j]:
+                block.insert(0, lines[j])
+                j -= 1
+            if j >= 0:
+                block.insert(0, lines[j])
+            cleaned = [b.strip().lstrip("/* ").rstrip("*/ ") for b in block]
+            comments = cleaned + comments
+            break
+        if line == "":
+            if comments:
+                break
+            j -= 1
+            continue
+        break
+    return "\n".join(c for c in comments if c).strip()
+
+
+def _extract_block(lines: List[str], start: int) -> Tuple[str, int]:
+    text_lines = [lines[start]]
+    brace = lines[start].count("{") - lines[start].count("}")
+    i = start + 1
+    while i < len(lines) and brace > 0:
+        line = lines[i]
+        text_lines.append(line)
+        brace += line.count("{") - line.count("}")
+        i += 1
+    return "\n".join(text_lines), i - 1
+
+
+def _parse_class_body(lines: List[str], start: int, end: int) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    methods: List[Dict[str, Any]] = []
+    variables: List[Dict[str, Any]] = []
+    i = start
+    while i <= end:
+        line = lines[i].strip()
+        if line.startswith("public "):
+            if "(" in line and line.rstrip().endswith("{"):
+                sig = line.rstrip("{").strip()
+                name = sig.split("(")[0].split()[-1]
+                doc = _get_preceding_comment(lines, i)
+                block, end_idx = _extract_block(lines, i)
+                methods.append({"name": name, "signature": sig, "docstring": doc, "source": block})
+                i = end_idx + 1
+                continue
+            if line.endswith(";") and "(" not in line:
+                parts = line.rstrip(";").split()
+                name = parts[-1]
+                vartype = " ".join(parts[1:-1])
+                doc = _get_preceding_comment(lines, i)
+                variables.append({"name": name, "type": vartype, "docstring": doc, "source": lines[i]})
+        i += 1
+    return methods, variables
+
+
+def parse_java_file(path: str) -> Dict[str, Any]:
+    text = Path(path).read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    first_code = 0
+    while first_code < len(lines):
+        stripped = lines[first_code].strip()
+        if stripped == "" or stripped.startswith("//") or stripped.startswith("/*"):
+            first_code += 1
+            continue
+        break
+    module_docstring = _get_preceding_comment(lines, first_code)
+
+    package = None
+    classes: List[Dict[str, Any]] = []
+    functions: List[Dict[str, Any]] = []
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if package is None and stripped.startswith("package "):
+            package = stripped.split()[1].rstrip(";")
+        if "class " in stripped:
+            tokens = stripped.split()
+            idx = tokens.index("class")
+            name = tokens[idx + 1]
+            if name.endswith("{"):
+                name = name[:-1]
+            doc = _get_preceding_comment(lines, i)
+            block, end_idx = _extract_block(lines, i)
+            methods, variables = _parse_class_body(lines, i + 1, end_idx - 1)
+            classes.append({"name": name, "docstring": doc, "methods": methods, "variables": variables, "source": block})
+            i = end_idx + 1
+            continue
+        i += 1
+
+    result: Dict[str, Any] = {"module_docstring": module_docstring, "classes": classes, "functions": functions}
+    if package:
+        result["package"] = package
+    return result

--- a/tests/test_parser_cpp.py
+++ b/tests/test_parser_cpp.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from parser_cpp import parse_cpp_file
+
+
+def test_parse_cpp(tmp_path: Path) -> None:
+    src = textwrap.dedent(
+        """
+        /** Module comment */
+        namespace demo {
+
+        /** Adds numbers */
+        int add(int a, int b) {
+            return a + b;
+        }
+
+        /** Greeter class */
+        class Greeter {
+        public:
+            /// name field
+            std::string name;
+
+            /// greet someone
+            std::string greet(const std::string& who) {
+                return "Hi " + who;
+            }
+        };
+        }
+        """
+    )
+    file = tmp_path / "sample.cpp"
+    file.write_text(src)
+
+    result = parse_cpp_file(str(file))
+    assert result["module_docstring"] == "Module comment"
+    assert result.get("namespace") == "demo"
+    assert len(result["functions"]) == 1
+    func = result["functions"][0]
+    assert func["name"] == "add"
+    assert func["docstring"] == "Adds numbers"
+    assert len(result["classes"]) == 1
+    cls = result["classes"][0]
+    assert cls["name"] == "Greeter"
+    assert cls["docstring"] == "Greeter class"
+    field = cls["variables"][0]
+    assert field["name"] == "name"
+    assert field["docstring"] == "name field"
+    method = cls["methods"][0]
+    assert method["name"] == "greet"
+    assert method["docstring"] == "greet someone"

--- a/tests/test_parser_java.py
+++ b/tests/test_parser_java.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from parser_java import parse_java_file
+
+
+def test_parse_java(tmp_path: Path) -> None:
+    src = textwrap.dedent(
+        """
+        /** Example package */
+        package demo;
+
+        /** Utility class */
+        public class Util {
+            /** public field */
+            public int count;
+
+            /** do work */
+            public void work() {}
+        }
+        """
+    )
+    file = tmp_path / "Sample.java"
+    file.write_text(src)
+
+    result = parse_java_file(str(file))
+    assert result["module_docstring"] == "Example package"
+    assert result.get("package") == "demo"
+    assert result["functions"] == []
+    assert len(result["classes"]) == 1
+    cls = result["classes"][0]
+    assert cls["name"] == "Util"
+    assert cls["docstring"] == "Utility class"
+    field = cls["variables"][0]
+    assert field["name"] == "count"
+    assert field["docstring"] == "public field"
+    method = cls["methods"][0]
+    assert method["name"] == "work"
+    assert method["docstring"] == "do work"


### PR DESCRIPTION
## Summary
- implement heuristic C++ parser capturing namespaces, classes, methods, variables and comments
- implement heuristic Java parser detecting package, classes, public members and comments
- add unit tests for C++ and Java parsing features

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `pip install --break-system-packages pytest` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ad21381e808322b913eecda7bbc44a