### PR TITLE
Add C++/Java parsing and variable summaries

### DIFF
--- a/parser_cpp.py
+++ b/parser_cpp.py
@@ -25,6 +25,9 @@ def _get_preceding_comment(lines: List[str], idx: int) -> str:
             j -= 1
             continue
         if line.endswith("*/"):
+            if "/*" in line:
+                comments.insert(0, line.strip().lstrip("/* ").rstrip("*/ "))
+                break
             block: List[str] = []
             block.insert(0, line)
             j -= 1


### PR DESCRIPTION
## Summary
- add C++ (.cpp/.h) and Java (.java) support in the doc generator
- include public variables in class chunking and summarization
- test docgenerator handling of C++ and Java files

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad22e1aab08322ab43ae3a601a3cc5