### PR TITLE
Add C++ and Java syntax highlighting

### DIFF
--- a/html_writer.py
+++ b/html_writer.py
@@ -9,7 +9,7 @@ from typing import Any, Iterable, Tuple, Dict
 import html
 
 from pygments import highlight
-from pygments.lexers import PythonLexer, MatlabLexer, TextLexer
+from pygments.lexers import PythonLexer, MatlabLexer, TextLexer, CppLexer, JavaLexer
 from pygments.formatters import HtmlFormatter
 
 _TEMPLATE_PATH = Path(__file__).parent / "templates" / "template.html"
@@ -21,6 +21,10 @@ def _highlight(code: str, language: str) -> str:
         lexer = MatlabLexer()
     elif language.lower() == "python":
         lexer = PythonLexer()
+    elif language.lower() == "cpp":
+        lexer = CppLexer()
+    elif language.lower() == "java":
+        lexer = JavaLexer()
     else:
         lexer = TextLexer()
     formatter = HtmlFormatter(noclasses=True, nowrap=True)

--- a/tests/test_html_writer.py
+++ b/tests/test_html_writer.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from html_writer import write_index, write_module_page
+from html_writer import write_index, write_module_page, _highlight
 
 
 def test_write_index(tmp_path: Path) -> None:
@@ -137,3 +137,10 @@ def test_subclass_rendering(tmp_path: Path) -> None:
     assert "Class: B" in html
     assert "def m(self)" in html
     assert html.count("<pre><code>") == 1
+
+
+def test_cpp_java_highlighting() -> None:
+    cpp_html = _highlight("int main() { return 0; }", "cpp")
+    java_html = _highlight("class T { int x; }", "java")
+    assert "<span" in cpp_html
+    assert "<span" in java_html


### PR DESCRIPTION
## Summary
- support C++ and Java lexers in HTML highlighter
- add tests ensuring syntax highlighting works for both languages

## Testing
- `pytest tests/test_html_writer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad2d8c3e208322b4bb33ae8626202e