### PR TITLE
Render variables in HTML documentation

### DIFF
--- a/html_writer.py
+++ b/html_writer.py
@@ -120,6 +120,23 @@ def _render_class(cls: dict[str, Any], language: str, level: int = 2) -> list[st
     if doc:
         parts.append(f"<p>{html.escape(doc)}</p>")
 
+    variables = cls.get("variables", [])
+    if variables:
+        var_section_tag = f"h{min(level + 1, 6)}"
+        parts.append(
+            f'<{var_section_tag} id="{cls_name}-variables">Variables</{var_section_tag}>'
+        )
+        for var in variables:
+            var_tag = f"h{min(level + 2, 6)}"
+            name = var.get("name", "")
+            parts.append(f'<{var_tag} id="{name}">{html.escape(name)}</{var_tag}>')
+            summary = var.get("summary") or var.get("docstring")
+            if summary:
+                parts.append(f"<p>{html.escape(summary)}</p>")
+            src = var.get("source")
+            if src:
+                parts.append(_highlight(src, language))
+
     for method in cls.get("methods", []):
         parts.extend(_render_function(method, language, level + 1, "Method: "))
 
@@ -151,6 +168,19 @@ def write_module_page(output_dir: str, module_data: dict[str, Any], page_links: 
 
     for cls in module_data.get("classes", []):
         body_parts.extend(_render_class(cls, language, 2))
+
+    module_vars = module_data.get("variables", [])
+    if module_vars:
+        body_parts.append('<h2 id="variables">Variables</h2>')
+        for var in module_vars:
+            var_name = var.get("name", "")
+            body_parts.append(f'<h3 id="{var_name}">{html.escape(var_name)}</h3>')
+            summary = var.get("summary") or var.get("docstring")
+            if summary:
+                body_parts.append(f"<p>{html.escape(summary)}</p>")
+            src = var.get("source")
+            if src:
+                body_parts.append(_highlight(src, language))
 
     if module_data.get("functions"):
         body_parts.append("<h2>Functions</h2>")

--- a/tests/test_html_writer.py
+++ b/tests/test_html_writer.py
@@ -30,11 +30,25 @@ def test_write_module_page(tmp_path: Path) -> None:
     module_data = {
         "name": "module1",
         "summary": "Module <summary>",
+        "variables": [
+            {
+                "name": "MOD_VAR",
+                "docstring": "Module <var>",
+                "source": "MOD_VAR = 1",
+            }
+        ],
         "classes": [
             {
                 "name": "Bar",
                 "summary": "Class <summary>",
                 "docstring": "Bar docs & stuff",
+                "variables": [
+                    {
+                        "name": "attr",
+                        "docstring": "Attr <docs>",
+                        "source": "attr = 1",
+                    }
+                ],
                 "methods": [
                     {
                         "name": "baz",
@@ -65,10 +79,18 @@ def test_write_module_page(tmp_path: Path) -> None:
     assert "Bar docs &amp; stuff" in html
     assert "Method: def baz(self): pass" in html
     assert "Baz &lt;docs&gt;" in html
+    assert "<h3 id=\"Bar-variables\">Variables</h3>" in html
+    assert "<h4 id=\"attr\">attr</h4>" in html
+    assert "Attr &lt;docs&gt;" in html
+    assert "attr <span" in html
+    assert "<h2 id=\"variables\">Variables</h2>" in html
+    assert "<h3 id=\"MOD_VAR\">MOD_VAR</h3>" in html
+    assert "Module &lt;var&gt;" in html
+    assert "MOD_VAR <span" in html
     assert "Func summary &amp; stuff" in html
     assert "<h2>Functions" in html
     assert "def foo(): pass" in html
-    assert html.count("<pre><code>") == 2
+    assert html.count("<pre><code>") == 4
 
 
 def test_subfunction_rendering(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Support "Variables" sections for classes and modules in html_writer
- Show variable names, summaries, and declaration snippets
- Test variable rendering for modules and classes

## Testing
- `pytest tests/test_html_writer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad2ed839c08322b19c103d7e88f97f