### PR TITLE
Support C++ and Java code in explaincode

### DIFF
--- a/Docs/explaincode.html
+++ b/Docs/explaincode.html
@@ -292,11 +292,14 @@
     <span style="color: #008000; font-weight: bold">return</span> section_map, file_map
 </code></pre>
 <h3 id="rank_code_files">rank_code_files(root: Path, patterns: list[str]) -&gt; list[Path]</h3>
-<p>The function `rank_code_files` ranks Python and MATLAB code files within a specified directory based on their relevance to documentation. It uses a combination of file extensions, directory names, and keyword patterns to assign scores to each file. The ranking is determined by the highest score, with ties broken by lexicographical order of the file paths.</p>
+<p>The function `rank_code_files` ranks Python, MATLAB, C++, C header, and Java code files within a specified directory based on their relevance to documentation. It uses a combination of file extensions, directory names, and keyword patterns to assign scores to each file. The ranking is determined by the highest score, with ties broken by lexicographical order of the file paths.</p>
 <pre><code><span style="color: #008000; font-weight: bold">def</span> <span style="color: #0000FF">rank_code_files</span>(root: Path, patterns: <span style="color: #008000">list</span>[<span style="color: #008000">str</span>]) <span style="color: #666666">-&gt;</span> <span style="color: #008000">list</span>[Path]:
-<span style="color: #bbbbbb">    </span><span style="color: #BA2121; font-style: italic">&quot;&quot;&quot;Return code files under ``root`` ranked by simple heuristics.&quot;&quot;&quot;</span>
+<span style="color: #bbbbbb">    </span><span style="color: #BA2121; font-style: italic">&quot;&quot;&quot;Return code files under ``root`` ranked by simple heuristics.
 
-    allowed_exts <span style="color: #666666">=</span> {<span style="color: #BA2121">&quot;.py&quot;</span>, <span style="color: #BA2121">&quot;.m&quot;</span>, <span style="color: #BA2121">&quot;.ipynb&quot;</span>}
+    Supports ``.py``, ``.m``, ``.ipynb``, ``.cpp``, ``.h``, and ``.java`` files.
+    &quot;&quot;&quot;</span>
+
+    allowed_exts <span style="color: #666666">=</span> {<span style="color: #BA2121">&quot;.py&quot;</span>, <span style="color: #BA2121">&quot;.m&quot;</span>, <span style="color: #BA2121">&quot;.ipynb&quot;</span>, <span style="color: #BA2121">&quot;.cpp&quot;</span>, <span style="color: #BA2121">&quot;.h&quot;</span>, <span style="color: #BA2121">&quot;.java&quot;</span>}
     skip_dirs <span style="color: #666666">=</span> {
         <span style="color: #BA2121">&quot;venv&quot;</span>,
         <span style="color: #BA2121">&quot;.git&quot;</span>,

--- a/explaincode.py
+++ b/explaincode.py
@@ -346,9 +346,12 @@ def map_evidence_to_sections(
 
 
 def rank_code_files(root: Path, patterns: list[str]) -> list[Path]:
-    """Return code files under ``root`` ranked by simple heuristics."""
+    """Return code files under ``root`` ranked by simple heuristics.
 
-    allowed_exts = {".py", ".m", ".ipynb"}
+    Supports ``.py``, ``.m``, ``.ipynb``, ``.cpp``, ``.h``, and ``.java`` files.
+    """
+
+    allowed_exts = {".py", ".m", ".ipynb", ".cpp", ".h", ".java"}
     skip_dirs = {
         "venv",
         ".git",

--- a/tests/test_explaincode.py
+++ b/tests/test_explaincode.py
@@ -351,6 +351,22 @@ def test_scan_code_categorizes_snippets(
     assert result["How to Run"] == {"c.py": "run the tool"}
 
 
+def test_rank_code_files_supports_cpp_h_java(tmp_path: Path) -> None:
+    files = [
+        tmp_path / "main.py",
+        tmp_path / "lib.cpp",
+        tmp_path / "lib.h",
+        tmp_path / "Main.java",
+        tmp_path / "ignore.txt",
+    ]
+    for f in files:
+        f.write_text("", encoding="utf-8")
+    ranked = explaincode.rank_code_files(tmp_path, [])
+    names = {p.name for p in ranked}
+    assert {"main.py", "lib.cpp", "lib.h", "Main.java"} <= names
+    assert "ignore.txt" not in names
+
+
 def test_llm_fill_placeholders_per_section_logging(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## Summary
- broaden allowed extensions to include `.cpp`, `.h`, and `.java`
- document newly supported languages in explaincode docs
- test detection of C++/header/Java source files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad315313d48322a9b477f821c00fe6