### PR TITLE
Document C++ and Java support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,47 @@ Optional flags:
 
 The LLM must be running and reachable via `llm_client.py`.
 
+### C++ Example
+
+Given a simple C++ file `adder.cpp`:
+
+```cpp
+// Adds two integers
+int add(int a, int b) {
+    return a + b;
+}
+```
+
+Generate documentation with:
+
+```bash
+python docgenerator.py ./cpp_project --output ./docs
+```
+
+DocGen-LM identifies the `add` function and renders it in the HTML output.
+
+### Java Example
+
+For a Java project containing `Calculator.java`:
+
+```java
+/** Utility math routines */
+public class Calculator {
+    // Adds two integers
+    public static int add(int a, int b) {
+        return a + b;
+    }
+}
+```
+
+Run the tool:
+
+```bash
+python docgenerator.py ./java_project --output ./docs
+```
+
+The generated docs list the `Calculator` class along with its public methods.
+
 ## GUI Usage
 
 Install `PyQt5` to enable the graphical interface:

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,10 @@ version = 0.1.0
 author = ""
 
 [options]
-py_modules = explaincode
+py_modules = 
+    explaincode
+    parser_cpp
+    parser_java
 install_requires =
     tqdm
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup()
+    setup(py_modules=["explaincode", "parser_cpp", "parser_java"])


### PR DESCRIPTION
## Summary
- Document C++ and Java parsing with code and CLI examples in the README.
- Include `parser_cpp` and `parser_java` in packaging configuration.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad3b727534832297bb10adfda2401a