### PR TITLE
Expand parser and integration tests for C++ and Java

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,6 +15,22 @@ def test_docgenerator_generates_html(tmp_path: Path) -> None:
     (project_dir / "hello.py").write_text('def hi():\n    """Say hi."""\n    return "hi"\n')
     # simple matlab file
     (project_dir / "util.m").write_text('% util function\nfunction y = util(x)\n y = x;\nend\n')
+    # simple C++ file
+    (project_dir / "math.cpp").write_text(
+        "/** Add numbers */\nint add(int a, int b) {\n    return a + b;\n}\n"
+    )
+    # simple Java file
+    (project_dir / "Greeter.java").write_text(
+        "/** Example package */\n"
+        "package demo;\n\n"
+        "/** Greeter class */\n"
+        "public class Greeter {\n"
+        "    /** say hi */\n"
+        "    public String greet() {\n"
+        "        return \"hi\";\n"
+        "    }\n"
+        "}\n"
+    )
 
     output_dir = tmp_path / "out"
 
@@ -29,9 +45,15 @@ def test_docgenerator_generates_html(tmp_path: Path) -> None:
     assert (output_dir / "index.html").exists()
     assert (output_dir / "hello.html").exists()
     assert (output_dir / "util.html").exists()
+    assert (output_dir / "math.html").exists()
+    assert (output_dir / "Greeter.html").exists()
 
     html = (output_dir / "hello.html").read_text(encoding="utf-8")
     assert "summary" in html
+    cpp_html = (output_dir / "math.html").read_text(encoding="utf-8")
+    java_html = (output_dir / "Greeter.html").read_text(encoding="utf-8")
+    assert "summary" in cpp_html
+    assert "summary" in java_html
 
 
 def test_static_copied_from_any_cwd(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_parser_cpp.py
+++ b/tests/test_parser_cpp.py
@@ -42,6 +42,7 @@ def test_parse_cpp(tmp_path: Path) -> None:
     func = result["functions"][0]
     assert func["name"] == "add"
     assert func["docstring"] == "Adds numbers"
+    assert "return a + b;" in func["source"]
     assert len(result["classes"]) == 1
     cls = result["classes"][0]
     assert cls["name"] == "Greeter"
@@ -49,6 +50,8 @@ def test_parse_cpp(tmp_path: Path) -> None:
     field = cls["variables"][0]
     assert field["name"] == "name"
     assert field["docstring"] == "name field"
+    assert "std::string name;" in field["source"]
     method = cls["methods"][0]
     assert method["name"] == "greet"
     assert method["docstring"] == "greet someone"
+    assert "std::string greet" in method["source"]

--- a/tests/test_parser_java.py
+++ b/tests/test_parser_java.py
@@ -37,6 +37,9 @@ def test_parse_java(tmp_path: Path) -> None:
     field = cls["variables"][0]
     assert field["name"] == "count"
     assert field["docstring"] == "public field"
+    assert field["type"] == "int"
+    assert "public int count;" in field["source"]
     method = cls["methods"][0]
     assert method["name"] == "work"
     assert method["docstring"] == "do work"
+    assert "public void work" in method["source"]


### PR DESCRIPTION
## Summary
- verify C++ parser captures source for functions, fields, and methods
- verify Java parser captures type and source metadata
- run docgenerator integration across Python, MATLAB, C++, and Java samples

## Testing
- `pytest tests/test_parser_cpp.py tests/test_parser_java.py tests/test_integration.py -q`
- `pytest` *(fails: stuck/KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3e0637488322b7942f98ac286043