### PR TITLE
Avoid preloading iterables in extract_snippets

### DIFF
--- a/explaincode.py
+++ b/explaincode.py
@@ -407,7 +407,9 @@ def extract_snippets(
 
     snippets: dict[Path, str] = {}
     start = time.perf_counter()
-    for idx, path in enumerate(tqdm(list(files), desc="Scanning code files")):
+    for idx, path in enumerate(
+        tqdm(files, desc="Scanning code files", total=len(files))
+    ):
         elapsed = time.perf_counter() - start
         logging.info("Considering %s (elapsed %.2fs)", path, elapsed)
         if idx >= max_files:


### PR DESCRIPTION
## Summary
- streamline code scanning by avoiding conversion of file iterables to lists
- provide explicit total to tqdm while iterating over files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1de7119448322a5a0d0459d131d6f