### PR TITLE
Add resume progress support to docgenerator

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,6 @@
 import os
+import os
+import os
 import sys
 from pathlib import Path
 
@@ -19,3 +21,16 @@ def test_cache_round_trip(tmp_path: Path) -> None:
 def test_cache_get_missing(tmp_path: Path) -> None:
     cache = ResponseCache(str(tmp_path / "cache.json"))
     assert cache.get("unknown") is None
+
+
+def test_progress_tracking(tmp_path: Path) -> None:
+    cache_file = tmp_path / "cache.json"
+    cache = ResponseCache(str(cache_file))
+    module_data = {"path": "mod.py", "summary": "s"}
+    cache.mark_done("mod.py", module_data)
+
+    new_cache = ResponseCache(str(cache_file))
+    assert new_cache.get_progress() == {"mod.py": module_data}
+
+    new_cache.clear_progress()
+    assert new_cache.get_progress() == {}


### PR DESCRIPTION
## Summary
- track module progress in `ResponseCache` and expose helpers to read/update/clear it
- load cached progress in `docgenerator` to skip previously processed modules and optionally clear when done
- test progress tracking behavior in cache

## Testing
- `pytest tests/test_cache.py -q`
- `pytest tests/test_docgenerator.py::test_generates_class_and_function_summaries -q`
- ⚠️ `pytest` *(interrupted after partial run)*


------
https://chatgpt.com/codex/tasks/task_e_68b5c18e69a8832296bfad7fd4d74e85