### PR TITLE
Add resume flag to control cached progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Optional flags:
 | `--llm-url`   | Base URL of the LLM server       |
 | `--model`     | Model name to use                |
 | `--max-context-tokens` | Override the model's context window |
-| `--resume`    | Continue from cached progress    |
+| `--resume`    | Continue from cached progress (default clears progress) |
 | `--clear-progress` | Remove saved progress after a run |
 
 The LLM must be running and reachable via `llm_client.py`.
@@ -52,9 +52,10 @@ The LLM must be running and reachable via `llm_client.py`.
 ### Automatic Progress Saving
 
 DocGen-LM stores intermediate results in a `cache.json` file inside the
-output directory. If the generator stops partway through, rerun it with
+output directory. Cached progress is cleared at startup unless `--resume`
+is supplied. If the generator stops partway through, rerun it with
 `--resume` to continue from the last saved point. Use `--clear-progress`
-to remove the saved state after a successful run.
+to remove the saved state after a successful run when resuming.
 
 Example of resuming an interrupted run:
 
@@ -64,13 +65,12 @@ python docgenerator.py ./my_project --output ./docs
 python docgenerator.py ./my_project --output ./docs --resume
 ```
 
-To rebuild from scratch, run with `--clear-progress` or delete
-`cache.json` manually:
+To rebuild from scratch, simply run without `--resume` (the default) or
+delete `cache.json` manually. To drop progress after a resumed run, use
+`--clear-progress`:
 
 ```bash
-python docgenerator.py ./my_project --output ./docs --clear-progress
-# or
-rm docs/cache.json
+python docgenerator.py ./my_project --output ./docs --resume --clear-progress
 ```
 
 ### C++ Example

--- a/docgenerator.py
+++ b/docgenerator.py
@@ -520,6 +520,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Maximum token context window for the LLM",
     )
     parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume from previously saved progress",
+    )
+    parser.add_argument(
         "--clear-progress",
         action="store_true",
         help="Clear saved progress after a successful run",
@@ -545,6 +550,8 @@ def main(argv: list[str] | None = None) -> int:
     shutil.copytree(static_dir, output_dir / "static", dirs_exist_ok=True)
 
     cache = ResponseCache(str(output_dir / "cache.json"))
+    if not args.resume:
+        cache.clear_progress()
     progress = cache.get_progress()
     processed_paths = set(progress.keys())
 
@@ -770,7 +777,11 @@ def main(argv: list[str] | None = None) -> int:
         cache.set_progress_entry(module.get("path", ""), module)
         processed_paths.add(module.get("path", ""))
 
-    if args.clear_progress or len(processed_paths) == len(files):
+    if (
+        not args.resume
+        or args.clear_progress
+        or len(processed_paths) == len(files)
+    ):
         cache.clear_progress()
 
     return 0

--- a/tests/test_resume_progress.py
+++ b/tests/test_resume_progress.py
@@ -52,7 +52,7 @@ def test_resume_progress(tmp_path, monkeypatch):
     monkeypatch.setattr(ResponseCache, "set_progress_entry", original_set_progress)
     module_calls.clear()
 
-    ret = docgenerator.main(["--output", str(out_dir), str(project_dir)])
+    ret = docgenerator.main(["--output", str(out_dir), str(project_dir), "--resume"])
     assert ret == 0
 
     assert [Path(p).name for p in module_calls] == ["mod2.py"]


### PR DESCRIPTION
## Summary
- add `--resume` CLI flag to docgenerator and only load cached progress when requested
- prevent progress cache from persisting unless `--resume` or `--clear-progress` conditions apply
- document resume behavior and update resume-progress test

## Testing
- `pytest tests/test_resume_progress.py -q`
- `pytest tests/test_docgenerator.py -q` *(fails: KeyboardInterrupt during test suite after 7 passed in ~2m)*


------
https://chatgpt.com/codex/tasks/task_e_68b60326690c832285fbc6e2c9c520c4