### PR TITLE
Improve tokenizer fallback

### DIFF
--- a/tests/test_chunk_utils.py
+++ b/tests/test_chunk_utils.py
@@ -21,7 +21,10 @@ def test_chunk_text_reconstructs_content() -> None:
 def test_chunk_text_splits_markdown_headings() -> None:
     tokenizer = get_tokenizer()
     text = "# H1\npara1\n\n# H2\npara2"
-    chunks = chunk_text(text, tokenizer, 4)
+    # The lightweight tokenizer overestimates token counts by splitting into
+    # very small pieces, so use a slightly larger chunk size here to ensure the
+    # heading and following paragraph stay together.
+    chunks = chunk_text(text, tokenizer, 8)
     assert len(chunks) == 2
     assert chunks[0].startswith("# H1")
     assert chunks[1].startswith("# H2")


### PR DESCRIPTION
## Summary
- overestimate token counts by splitting text into 1–2 character pieces when tiktoken is unavailable
- emit stronger warning with optional strict mode for missing tiktoken
- update chunking test to account for conservative tokenizer

## Testing
- `pytest` *(killed after test_docgenerator)*
- `pytest tests/test_chunk_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8c2b0979c8322b24e00d90e7dd212