### PR TITLE
Filter prompt instructions from summaries

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -88,6 +88,8 @@ def sanitize_summary(text: str) -> str:
     text = re.sub(r"<\|f(?:im|m)_(?:prefix|middle|suffix)\|>", "", text)
 
     BAD_START_PHRASES = [
+        "summarize",
+        "you are",
         "you can",
         "note that",
         "the code above",
@@ -108,6 +110,8 @@ def sanitize_summary(text: str) -> str:
     ]
 
     BAD_CONTAINS = [
+        "documentation engine",
+        "summarize the following",
         "as an ai language model",
         "as a language model",
         "as an ai model",

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -59,6 +59,8 @@ def test_sanitize_summary_filters_phrases() -> None:
     text = (
         "You can run this.\n"
         "Note that it is simple.\n"
+        "Summarize the following function.\n"
+        "You are a documentation engine.\n"
         "Defines a class.\n"
         "This summary does not include disclaimers.\n"
         "This script does nothing.\n"


### PR DESCRIPTION
## Summary
- extend summary sanitization to drop prompt instructions like "summarize" and "you are"
- cover sanitization of prompt leaks with unit tests

## Testing
- `pytest tests/test_llm_client.py tests/test_sanitize_docs.py`
- `pytest` *(failed: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0259549f0832297890da15c4f9d6f