### PR TITLE
Revert chunking change that broke doc sanitization

### DIFF
--- a/manual_utils.py
+++ b/manual_utils.py
@@ -40,6 +40,8 @@ def _split_text(text: str, max_tokens: int = 2000, max_chars: int = 6000) -> lis
     current: list[str] = []
     token_count = 0
     char_count = 0
+    sep_tokens = _count_tokens("\n\n")
+    sep_chars = 2
     for para in paragraphs:
         para = para.strip()
         if not para:
@@ -48,25 +50,27 @@ def _split_text(text: str, max_tokens: int = 2000, max_chars: int = 6000) -> lis
         pchars = len(para)
         if ptokens > max_tokens or pchars > max_chars:
             if current:
-                chunks.append("\n".join(current).strip())
+                chunks.append("\n\n".join(current).strip())
                 current = []
                 token_count = 0
                 char_count = 0
             for piece in chunk_text(para, TOKENIZER, max_tokens):
                 chunks.append(piece.strip())
             continue
-        if token_count + ptokens > max_tokens or char_count + pchars > max_chars:
+        extra_tokens = ptokens if not current else ptokens + sep_tokens
+        extra_chars = pchars if not current else pchars + sep_chars
+        if token_count + extra_tokens > max_tokens or char_count + extra_chars > max_chars:
             if current:
-                chunks.append("\n".join(current).strip())
+                chunks.append("\n\n".join(current).strip())
             current = [para]
             token_count = ptokens
             char_count = pchars
         else:
             current.append(para)
-            token_count += ptokens
-            char_count += pchars
+            token_count += extra_tokens
+            char_count += extra_chars
     if current:
-        chunks.append("\n".join(current).strip())
+        chunks.append("\n\n".join(current).strip())
     return chunks
 
 

--- a/tests/test_manual_utils.py
+++ b/tests/test_manual_utils.py
@@ -8,7 +8,7 @@ def _count(text: str) -> int:
 def test_chunk_docs_respects_token_limit() -> None:
     docs = ["a " * 1000, "b " * 1000, "c " * 1000]
     chunks = manual_utils.chunk_docs(docs, token_limit=2000)
-    assert len(chunks) == 2
+    assert len(chunks) == 3
     assert all(_count(c) <= 2000 for c in chunks)
 
 


### PR DESCRIPTION
## Summary
- restore manual text chunking to use double newlines between paragraphs
- improve token accounting when splitting text into manual chunks
- adjust manual chunking test for new behaviour

## Testing
- `pytest -q` *(killed)*
- `pytest tests/test_manual_utils.py tests/test_chunk_utils.py -q`
- `pytest tests/test_sanitize_docs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0451ed788832283688d5d9b9f6a81