### PR TITLE
Sanitize additional HTML tags in docs

### DIFF
--- a/sanitize_docs.py
+++ b/sanitize_docs.py
@@ -11,11 +11,13 @@ from llm_client import sanitize_summary
 
 def _sanitize_html(html: str) -> str:
     def repl(match: re.Match[str]) -> str:
-        inner = re.sub(r"<[^>]+>", "", match.group(1))
+        tag, content = match.group(1), match.group(2)
+        inner = re.sub(r"<[^>]+>", "", content)
         cleaned = sanitize_summary(inner)
-        return f"<p>{cleaned}</p>"
+        return f"<{tag}>{cleaned}</{tag}>"
 
-    return re.sub(r"<p>(.*?)</p>", repl, html, flags=re.DOTALL | re.IGNORECASE)
+    pattern = r"<(p|li|h[1-6])>(.*?)</\1>"
+    return re.sub(pattern, repl, html, flags=re.DOTALL | re.IGNORECASE)
 
 
 def sanitize_directory(directory: Path) -> None:

--- a/tests/test_sanitize_docs.py
+++ b/tests/test_sanitize_docs.py
@@ -17,3 +17,20 @@ def test_sanitize_directory_removes_ai_disclaimer(tmp_path: Path) -> None:
     result = html_path.read_text(encoding="utf-8")
     assert "As an AI language model" not in result
     assert "<p>It prints output.</p>" in result
+
+
+def test_sanitize_directory_handles_headings_and_list_items(tmp_path: Path) -> None:
+    html_path = tmp_path / "page.html"
+    html_path.write_text(
+        (
+            "<h2>As an AI language model, I cannot do that.\nIt prints output.</h2>"
+            "<li>You can run this.\nIt prints output.</li>"
+        ),
+        encoding="utf-8",
+    )
+    main([str(tmp_path)])
+    result = html_path.read_text(encoding="utf-8")
+    assert "As an AI language model" not in result
+    assert "You can run this" not in result
+    assert "<h2>It prints output.</h2>" in result
+    assert "<li>It prints output.</li>" in result


### PR DESCRIPTION
## Summary
- sanitize more HTML tags (paragraphs, list items, headings) to ensure generated docs strip AI disclaimers
- test sanitization of headings and list items

## Testing
- `pytest tests/test_sanitize_docs.py -q`
- `pytest` *(failed: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68c04f0310988322b5dc8d91ca5b136e