### PR TITLE
Revert code fence splitting to prevent prompt leakage

### DIFF
--- a/chunk_utils.py
+++ b/chunk_utils.py
@@ -37,20 +37,10 @@ def get_tokenizer():
 
     class _Simple:
         def encode(self, text: str):
-            import re
-
-            return re.findall(r"\S+|\n", text)
+            return text.split()
 
         def decode(self, tokens):
-            parts = []
-            for i, t in enumerate(tokens):
-                if t == "\n":
-                    parts.append("\n")
-                else:
-                    parts.append(t)
-                    if i + 1 < len(tokens) and tokens[i + 1] != "\n":
-                        parts.append(" ")
-            return "".join(parts)
+            return " ".join(tokens)
 
     return _Simple()
 
@@ -104,13 +94,7 @@ def _split_blocks(text: str) -> List[str]:
 
 
 def _split_long_block(block: str, tokenizer, chunk_size_tokens: int) -> List[str]:
-    """Fallback splitter that uses a character based approximation.
-
-    When splitting a fenced code block the fences are replicated for every
-    produced chunk so that each piece remains a valid fenced block.  This
-    prevents prompt leakage where a truncated fence could cause the language
-    model to treat subsequent text as instructions instead of code.
-    """
+    """Fallback splitter that uses a character based approximation."""
 
     tokens = tokenizer.encode(block)
     if len(tokens) <= chunk_size_tokens:
@@ -118,26 +102,6 @@ def _split_long_block(block: str, tokenizer, chunk_size_tokens: int) -> List[str
 
     avg_chars = max(len(block) // len(tokens), 1)
     max_chars = max(chunk_size_tokens * avg_chars, 1)
-
-    # Special handling for fenced code blocks – ensure each chunk has fences.
-    if block.startswith("```") and block.rstrip().endswith("```"):
-        lines = block.splitlines()
-        fence = lines[0]
-        code_lines = lines[1:-1]
-        pieces: List[str] = []
-        current: List[str] = []
-        length = 0
-        for line in code_lines:
-            current.append(line)
-            length += len(line)
-            if length >= max_chars:
-                pieces.append("\n".join(current))
-                current = []
-                length = 0
-        if current:
-            pieces.append("\n".join(current))
-        return [f"{fence}\n{piece}\n```" for piece in pieces]
-
     return [block[i : i + max_chars] for i in range(0, len(block), max_chars)]
 
 

--- a/tests/test_chunk_utils.py
+++ b/tests/test_chunk_utils.py
@@ -34,15 +34,3 @@ def test_chunk_text_preserves_code_blocks() -> None:
     assert any("```python\nprint('hi')\n```" in chunk for chunk in chunks)
     for chunk in chunks:
         assert chunk.count("```") in (0, 2)
-
-
-def test_chunk_text_splits_long_code_block_with_fences() -> None:
-    tokenizer = get_tokenizer()
-    code = "print('hi')\n" * 100
-    text = f"```python\n{code}```"
-    chunks = chunk_text(text, tokenizer, 20)
-    assert len(chunks) > 1
-    for chunk in chunks:
-        assert chunk.startswith("```python")
-        assert chunk.strip().endswith("```")
-        assert chunk.count("```") == 2


### PR DESCRIPTION
## Summary
- revert commit `c652bd5` that altered tokenization and fenced block splitting
- restore simple whitespace tokenization and character-based splitting logic
- remove extra test case related to code fence splitting

## Testing
- `pytest tests/test_chunk_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68c07eae28008322b1162204af985b71