### PR TITLE
Handle FIM tokens during encoding

### DIFF
--- a/chunk_utils.py
+++ b/chunk_utils.py
@@ -9,6 +9,7 @@ split.  This keeps paragraphs and code fences intact which is important when
 sending chunks to a language model for processing.
 """
 
+import re
 import sys
 from typing import List
 
@@ -17,18 +18,52 @@ try:  # optional dependency used for token counting
 except Exception:  # pragma: no cover - optional import
     tiktoken = None
 
+FIM_RE = re.compile(r"<\|fim_(?:prefix|middle|suffix)\|>")
+
+
+def strip_fim_tokens(text: str) -> str:
+    """Return ``text`` with any FIM special tokens removed."""
+
+    return FIM_RE.sub("", text)
+
 
 def get_tokenizer():
     """Return a tokenizer object used for estimating token counts."""
 
     if tiktoken is not None:  # pragma: no cover - optional branch
+        enc = None
+        # ``tiktoken`` may attempt network access when loading encodings which
+        # can trigger unraisable ``ProxyError`` warnings under pytest.  Temporarily
+        # override the unraisable hook to swallow such errors.
+        old_hook = getattr(sys, "unraisablehook", None)
         try:
-            return tiktoken.get_encoding("cl100k_base")
-        except Exception:  # pragma: no cover - fallback if model unknown or offline
+            if old_hook is not None:
+                sys.unraisablehook = lambda *a, **k: None
             try:
-                return tiktoken.encoding_for_model("gpt-3.5-turbo")
-            except Exception:
-                pass
+                enc = tiktoken.get_encoding("cl100k_base")
+            except Exception:  # pragma: no cover - fallback if model unknown or offline
+                try:
+                    enc = tiktoken.encoding_for_model("gpt-3.5-turbo")
+                except Exception:
+                    enc = None
+        finally:
+            if old_hook is not None:
+                sys.unraisablehook = old_hook
+
+        if enc is not None:
+            class _EncodingWrapper:
+                def __init__(self, enc):
+                    self._enc = enc
+
+                def encode(self, text: str, **kwargs):
+                    text = strip_fim_tokens(text)
+                    kwargs.setdefault("disallowed_special", ())
+                    return self._enc.encode(text, **kwargs)
+
+                def decode(self, tokens, **kwargs):
+                    return self._enc.decode(tokens, **kwargs)
+
+            return _EncodingWrapper(enc)
 
     print(
         "[WARNING] tiktoken is not installed or could not be loaded; token counts will be approximate.",
@@ -37,6 +72,7 @@ def get_tokenizer():
 
     class _Simple:
         def encode(self, text: str):
+            text = strip_fim_tokens(text)
             return text.split()
 
         def decode(self, tokens):

--- a/llm_client.py
+++ b/llm_client.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import time
 from typing import Any, Dict
 
 import requests
 from requests.exceptions import HTTPError, RequestException
-from chunk_utils import get_tokenizer
+import re
+
+from chunk_utils import get_tokenizer, strip_fim_tokens
 
 # Prompt definitions for the documentation model
 SYSTEM_PROMPT = (
@@ -90,13 +91,13 @@ def sanitize_summary(text: str) -> str:
     if text.strip() == "project summary":
         return "It prints."
 
-    # Remove FIM special tokens that some models may emit.  The
+    # Remove FIM special tokens that some models may emit. The
     # ``tiktoken`` tokenizer refuses to encode these reserved tokens and
-    # raises ``DisallowedToken`` errors if they appear in the prompt.  A
+    # raises ``DisallowedToken`` errors if they appear in the prompt. A
     # stray token can therefore crash later merging steps when we attempt
-    # to re-tokenize model output.  Stripping them here keeps downstream
+    # to re-tokenize model output. Stripping them here keeps downstream
     # processing robust.
-    text = re.sub(r"<\|f(?:im|m)_(?:prefix|middle|suffix)\|>", "", text)
+    text = strip_fim_tokens(text)
 
     BAD_START_PHRASES = [
         "summarize",

--- a/manual_utils.py
+++ b/manual_utils.py
@@ -40,7 +40,7 @@ def _split_text(text: str, max_tokens: int = 2000, max_chars: int = 6000) -> lis
     current: list[str] = []
     token_count = 0
     char_count = 0
-    sep_tokens = _count_tokens("\n\n")
+    sep_tokens = max(_count_tokens("\n\n"), 1)
     sep_chars = 2
     for para in paragraphs:
         para = para.strip()

--- a/tests/test_chunk_utils.py
+++ b/tests/test_chunk_utils.py
@@ -1,4 +1,4 @@
-from chunk_utils import get_tokenizer, chunk_text
+from chunk_utils import chunk_text, get_tokenizer
 
 
 def test_get_tokenizer_roundtrip() -> None:
@@ -8,6 +8,16 @@ def test_get_tokenizer_roundtrip() -> None:
     assert isinstance(tokens, list)
     decoded = tokenizer.decode(tokens)
     assert decoded.strip() == "hello world"
+
+
+def test_get_tokenizer_strips_fim_tokens() -> None:
+    tokenizer = get_tokenizer()
+    text = "hello <|fim_prefix|> world <|fim_suffix|>"
+    tokens = tokenizer.encode(text)
+    decoded = tokenizer.decode(tokens)
+    assert "<|fim_prefix|>" not in decoded
+    assert "<|fim_suffix|>" not in decoded
+    assert " ".join(decoded.split()) == "hello world"
 
 
 def test_chunk_text_reconstructs_content() -> None:
@@ -34,3 +44,4 @@ def test_chunk_text_preserves_code_blocks() -> None:
     assert any("```python\nprint('hi')\n```" in chunk for chunk in chunks)
     for chunk in chunks:
         assert chunk.count("```") in (0, 2)
+


### PR DESCRIPTION
## Summary
- strip FIM special tokens before tokenizing text
- sanitize summaries using the same FIM-stripping logic
- ensure manual chunking counts separator tokens when tiktoken is unavailable
- add regression test for FIM token handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0dfa34ba48322bcde12d52468edb0