### PR TITLE
Handle partial prompt lines in summary sanitization

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -136,7 +136,10 @@ def sanitize_summary(text: str) -> str:
     for line in lines:
         stripped = line.strip()
         line_lower = stripped.lower()
-        if line_lower in PROMPT_LINE_SET or line_lower in SYSTEM_PROMPT_LINES:
+        if any(
+            p in line_lower or line_lower in p
+            for p in PROMPT_LINE_SET.union(SYSTEM_PROMPT_LINES)
+        ):
             continue
         if stripped.startswith("-") or stripped.startswith("*"):
             continue

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -90,6 +90,22 @@ def test_sanitize_summary_removes_prompt_lines() -> None:
     assert sanitize_summary(text) == "Defines a class."
 
 
+def test_sanitize_summary_filters_altered_prompt_line() -> None:
+    text = (
+        "Code: example snippet\n"
+        "Defines a class."
+    )
+    assert sanitize_summary(text) == "Defines a class."
+
+
+def test_sanitize_summary_filters_truncated_prompt_line() -> None:
+    text = (
+        "Do not say what is or isn't included in the code\n"
+        "Defines a class."
+    )
+    assert sanitize_summary(text) == "Defines a class."
+
+
 def test_prompt_varies_by_type() -> None:
     client = LLMClient("http://fake")
     mock_response = Mock()


### PR DESCRIPTION
## Summary
- Remove lines in `sanitize_summary` that contain or are contained in known prompt text to avoid partial prompt leakage
- Test that truncated and altered prompt lines are filtered from summaries

## Testing
- `pytest tests/test_llm_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0f4d8096c8322accbe9dfcf7a6c00