### PR TITLE
Allow smaller chunk budgets in DocGen CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ Optional flags:
 | `--llm-url`   | Base URL of the LLM server       |
 | `--model`     | Model name to use                |
 | `--max-context-tokens` | Override the model's context window |
+| `--chunk-token-budget` | Limit tokens per chunk (default 75% of context) |
 | `--resume`    | Continue from cached progress (default clears progress) |
 | `--clear-progress` | Remove saved progress after a run |
 
 The LLM must be running and reachable via `llm_client.py`.
+
+Reduce `--chunk-token-budget` when using models with very small context
+windows to keep chunks well within the limit and avoid prompt leakage.
 
 ### Automatic Progress Saving
 

--- a/docgenerator.py
+++ b/docgenerator.py
@@ -522,6 +522,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Maximum token context window for the LLM",
     )
     parser.add_argument(
+        "--chunk-token-budget",
+        type=int,
+        help="Maximum tokens per chunk (defaults to 75% of context)",
+    )
+    parser.add_argument(
         "--resume",
         action="store_true",
         help="Resume from previously saved progress",
@@ -551,7 +556,11 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
     max_context_tokens = min(max_context_tokens, MAX_CHUNK_TOKENS)
-    chunk_token_budget = int(max_context_tokens * 0.75)
+    default_chunk_budget = int(max_context_tokens * 0.75)
+    if args.chunk_token_budget is not None:
+        chunk_token_budget = min(args.chunk_token_budget, default_chunk_budget)
+    else:
+        chunk_token_budget = default_chunk_budget
     chunk_token_budget = min(chunk_token_budget, MAX_CHUNK_TOKENS)
 
     output_dir = Path(args.output)


### PR DESCRIPTION
## Summary
- add `--chunk-token-budget` option to control tokens per chunk
- compute default from 75% of context window and clamp
- document the new flag for tuning smaller models

## Testing
- `pytest -q` *(fails: tests/test_explaincode.py::test_hierarchical_merge_logged)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fa09fec08322ac704fdc5a3f0dad