### PR TITLE
Add gitignore entry for Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- add a repository-level .gitignore that ignores Python __pycache__ directories and compiled bytecode files

## Testing
- git status --ignored -sb

------
https://chatgpt.com/codex/tasks/task_e_68d5a5a5ede883229474537b0b886659